### PR TITLE
Fix severe CSRF vulnerabilities in /local-api endpoints

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -168,16 +168,18 @@ export async function backendCall<T = any>(
 
   const method = options?.method || endpoint.method || "GET";
   const fetchOptions: RequestInit = { method };
+  const headers: Record<string, string> = { "x-locally-uncensored": "true" };
 
   if (options?.body) {
     fetchOptions.body = options.body;
     if (options.headers) {
-      fetchOptions.headers = options.headers;
+      Object.assign(headers, options.headers);
     }
   } else if (args && method !== "GET") {
-    fetchOptions.headers = { "Content-Type": "application/json" };
+    headers["Content-Type"] = "application/json";
     fetchOptions.body = JSON.stringify(args);
   }
+  fetchOptions.headers = headers;
 
   // For GET with args, append as query params
   let url = endpoint.path;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,6 +141,44 @@ function comfyLauncher(): Plugin {
   return {
     name: 'comfy-launcher',
     configureServer(server) {
+      // --- Security Middleware ---
+      server.middlewares.use('/local-api', (req, res, next) => {
+        // Exclude GET proxy-image/download from strict header checks (used in <img> tags and simple fetches)
+        if (req.method === 'GET' && (req.url?.startsWith('/proxy-image') || req.url?.startsWith('/proxy-download'))) {
+          return next();
+        }
+
+        // 1. Strict Content-Type enforcement for POST requests
+        if (req.method === 'POST') {
+           const contentType = req.headers['content-type'] || '';
+           if (!contentType.includes('application/json')) {
+               res.writeHead(415, { 'Content-Type': 'text/plain' });
+               res.end('Unsupported Media Type: Must be application/json');
+               return;
+           }
+        }
+        
+        // 2. Custom Header Requirement (CSRF Protection)
+        if (req.headers['x-locally-uncensored'] !== 'true') {
+           res.writeHead(403, { 'Content-Type': 'text/plain' });
+           res.end('Forbidden: Missing x-locally-uncensored header (CSRF Protection)');
+           return;
+        }
+
+        // 3. Strict Origin Validation (Defense in Depth)
+        const origin = req.headers.origin;
+        if (origin) {
+            const allowedOrigins = ['http://localhost:5173', 'http://127.0.0.1:5173', 'tauri://localhost', 'http://tauri.localhost'];
+            if (!allowedOrigins.includes(origin)) {
+                res.writeHead(403, { 'Content-Type': 'text/plain' });
+                res.end('Forbidden: Invalid Origin (CSRF Protection)');
+                return;
+            }
+        }
+
+        next();
+      });
+
       // Auto-start Ollama when dev server starts
       try {
         execSync('tasklist /FI "IMAGENAME eq ollama.exe" | find /I "ollama.exe"', { stdio: 'ignore' })


### PR DESCRIPTION
This PR fixes a severe Cross-Site Request Forgery (CSRF) vulnerability in the local API endpoints exposed by Vite dev server. By enforcing `Content-Type: application/json` validation and a new custom header requirement (`x-locally-uncensored: true`), we prevent malicious websites from executing code or terminal commands locally. The backend proxy fetching utility (`backendCall`) in `src/api/backend.ts` has been updated to automatically attach this header, so no functionality is broken.
