### PR TITLE
Fix missing Content-Type in backendCall

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -175,9 +175,9 @@ export async function backendCall<T = any>(
     if (options.headers) {
       Object.assign(headers, options.headers);
     }
-  } else if (args && method !== "GET") {
+  } else if (method !== "GET") {
     headers["Content-Type"] = "application/json";
-    fetchOptions.body = JSON.stringify(args);
+    fetchOptions.body = JSON.stringify(args || {});
   }
   fetchOptions.headers = headers;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -729,12 +729,15 @@ function comfyLauncher(): Plugin {
             let envContent = ''
             try { envContent = readFileSync(envPath, 'utf8') } catch { /* no .env yet */ }
 
-            if (envContent.includes('COMFYUI_PATH=')) {
-              envContent = envContent.replace(/COMFYUI_PATH=.*/g, `COMFYUI_PATH=${newPath}`)
-            } else {
-              envContent += `${envContent.endsWith('\n') ? '' : '\n'}COMFYUI_PATH=${newPath}\n`
+            const currentMatch = envContent.match(/^COMFYUI_PATH=(.*)$/m)
+            if (!currentMatch || currentMatch[1].trim() !== newPath) {
+              if (envContent.includes('COMFYUI_PATH=')) {
+                envContent = envContent.replace(/COMFYUI_PATH=.*/g, `COMFYUI_PATH=${newPath}`)
+              } else {
+                envContent += `${envContent.endsWith('\n') || envContent === '' ? '' : '\n'}COMFYUI_PATH=${newPath}\n`
+              }
+              writeFileSync(envPath, envContent, 'utf8')
             }
-            writeFileSync(envPath, envContent, 'utf8')
 
             // Update process.env
             process.env.COMFYUI_PATH = newPath
@@ -859,12 +862,15 @@ function comfyLauncher(): Plugin {
             const { writeFileSync, readFileSync } = require('fs')
             let envContent = ''
             try { envContent = readFileSync(envPath, 'utf8') } catch { /* no .env */ }
-            if (envContent.includes('COMFYUI_PATH=')) {
-              envContent = envContent.replace(/COMFYUI_PATH=.*/g, `COMFYUI_PATH=${installDir}`)
-            } else {
-              envContent += `${envContent.endsWith('\n') ? '' : '\n'}COMFYUI_PATH=${installDir}\n`
+            const currentMatch = envContent.match(/^COMFYUI_PATH=(.*)$/m)
+            if (!currentMatch || currentMatch[1].trim() !== installDir) {
+              if (envContent.includes('COMFYUI_PATH=')) {
+                envContent = envContent.replace(/COMFYUI_PATH=.*/g, `COMFYUI_PATH=${installDir}`)
+              } else {
+                envContent += `${envContent.endsWith('\n') || envContent === '' ? '' : '\n'}COMFYUI_PATH=${installDir}\n`
+              }
+              writeFileSync(envPath, envContent, 'utf8')
             }
-            writeFileSync(envPath, envContent, 'utf8')
             process.env.COMFYUI_PATH = installDir
             log(`Path saved to .env: ${installDir}`)
 


### PR DESCRIPTION
This fixes a regression introduced by PR #19 where POST requests without a body (like \install_comfyui\) were missing the \Content-Type: application/json\ header, causing an HTTP 415 error from the local API middleware.

Apologies, looks like I broke the onboarding with that last one.