### PR TITLE
Fix ComfyUI connection/start issues, filter partials from fallback, and implement resuming

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["stream", "blocking", "json"] }
+reqwest = { version = "0.12", features = ["stream", "blocking", "json", "multipart"] }
 zip = "2"
 dirs = "6"
 regex = "1"

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -398,3 +398,46 @@ pub async fn ollama_search(query: String) -> Result<serde_json::Value, String> {
         Err(_) => Ok(serde_json::json!({"models": []})),
     }
 }
+
+/// Upload an image to ComfyUI, bypassing CORS.
+#[tauri::command]
+pub async fn proxy_comfyui_upload(
+    file_bytes: Vec<u8>,
+    filename: String,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<String, String> {
+    let host = state.comfy_host.lock().unwrap().clone();
+    let port = *state.comfy_port.lock().unwrap();
+    let url = format!("http://{}:{}/upload/image", host, port);
+
+    validate_proxy_url(&url, &state)?;
+
+    let part = reqwest::multipart::Part::bytes(file_bytes)
+        .file_name(filename.clone())
+        .mime_str("application/octet-stream")
+        .map_err(|e| e.to_string())?;
+
+    let form = reqwest::multipart::Form::new()
+        .part("image", part)
+        .text("overwrite", "true");
+
+    let client = reqwest::Client::builder()
+        .user_agent("LocallyUncensored/2.0")
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let resp = client.post(&url)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| format!("proxy_comfyui_upload error: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("HTTP {}: {}", status, text));
+    }
+
+    resp.text().await.map_err(|e| e.to_string())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -153,6 +153,7 @@ fn main() {
             commands::proxy::fetch_external_bytes,
             commands::proxy::proxy_localhost,
             commands::proxy::proxy_localhost_stream,
+            commands::proxy::proxy_comfyui_upload,
             commands::proxy::pull_model_stream,
             commands::proxy::cancel_model_pull,
             // Window management

--- a/src/api/comfyui.ts
+++ b/src/api/comfyui.ts
@@ -1,4 +1,4 @@
-import { comfyuiUrl, localFetch } from "./backend"
+import { comfyuiUrl, localFetch, isTauri } from "./backend"
 
 // ─── Types ───
 
@@ -810,6 +810,18 @@ export async function getHistory(promptId: string): Promise<any> {
 // ─── Upload image to ComfyUI (for I2V models like SVD, FramePack) ───
 
 export async function uploadImage(file: File): Promise<string> {
+  if (isTauri()) {
+    const arrayBuffer = await file.arrayBuffer()
+    const fileBytes = Array.from(new Uint8Array(arrayBuffer))
+    const { invoke } = await import('@tauri-apps/api/core')
+    const resText = await invoke<string>('proxy_comfyui_upload', {
+      fileBytes,
+      filename: file.name,
+    })
+    const data = JSON.parse(resText)
+    return data.name
+  }
+
   const formData = new FormData()
   formData.append('image', file)
   formData.append('overwrite', 'true')

--- a/src/api/discover.ts
+++ b/src/api/discover.ts
@@ -1,5 +1,5 @@
 import { backendCall, fetchExternal } from "./backend"
-import { getCheckpoints, getDiffusionModels, getVAEModels, getCLIPModels } from "./comfyui"
+import { getCheckpoints, getDiffusionModels, getVAEModels, getCLIPModels, filterPartialFiles } from "./comfyui"
 import type { ProviderId } from "./providers/types"
 
 export interface DiscoverModel {
@@ -122,8 +122,14 @@ export async function checkBundlesInstalled(bundles: ModelBundle[]): Promise<Rec
   const undetected = bundles.filter(b => !result[b.name])
   if (undetected.length > 0) {
     try {
-      const [checkpoints, diffModels, vaes, clips] = await Promise.all([
+      const [rawCheckpoints, rawDiffModels, rawVaes, rawClips] = await Promise.all([
         getCheckpoints(), getDiffusionModels(), getVAEModels(), getCLIPModels(),
+      ])
+      const [checkpoints, diffModels, vaes, clips] = await Promise.all([
+        filterPartialFiles(rawCheckpoints).then(s => Array.from(s)),
+        filterPartialFiles(rawDiffModels).then(s => Array.from(s)),
+        filterPartialFiles(rawVaes).then(s => Array.from(s)),
+        filterPartialFiles(rawClips).then(s => Array.from(s)),
       ])
       const modelsBySubfolder: Record<string, string[]> = {
         checkpoints, diffusion_models: diffModels, vae: vaes, text_encoders: clips,

--- a/src/api/ollama.ts
+++ b/src/api/ollama.ts
@@ -324,3 +324,12 @@ export async function checkConnection(): Promise<boolean> {
     return false
   }
 }
+
+export async function createOllamaModel(name: string, modelfile: string): Promise<Response> {
+  const res = await localFetchStream(isTauri() ? ollamaUrl("/create") : "/api/create", {
+    method: "POST",
+    body: JSON.stringify({ name, modelfile, stream: false }),
+  })
+  if (!res.ok) throw new Error("Failed to create model in Ollama")
+  return res
+}

--- a/src/components/create/CreateView.tsx
+++ b/src/components/create/CreateView.tsx
@@ -183,7 +183,7 @@ export function CreateView() {
     connected, imageModels, videoModels, samplerList, schedulerList,
     videoBackend, modelsLoaded, modelLoadError, checkConnection, fetchModels, runPreflight, generate, cancel,
   } = useCreate()
-  const { mode, setMode, imageSubMode, error, preflightReady, preflightErrors, preflightWarnings, videoModel, i2vImage, setI2vImage, i2iImage, setI2iImage, denoise, setDenoise } = useCreateStore()
+  const { mode, setMode, imageSubMode, error, setError, preflightReady, preflightErrors, preflightWarnings, videoModel, i2vImage, setI2vImage, i2iImage, setI2iImage, denoise, setDenoise } = useCreateStore()
 
   const [status, setStatus] = useState<ComfyStatus | null>(null)
   const [startupLogs, setStartupLogs] = useState<string[]>([])
@@ -341,11 +341,13 @@ export function CreateView() {
   const handleI2vUpload = async (file: File) => {
     if (!file.type.startsWith('image/')) return
     setI2vUploading(true)
+    setError(null)
     try {
       const filename = await uploadImage(file)
       setI2vImage(filename)
     } catch (err) {
       console.error('[CreateView] I2V image upload failed:', err)
+      setError(err instanceof Error ? err.message : String(err))
     }
     setI2vUploading(false)
   }
@@ -360,11 +362,13 @@ export function CreateView() {
   const handleI2iUpload = async (file: File) => {
     if (!file.type.startsWith('image/')) return
     setI2iUploading(true)
+    setError(null)
     try {
       const filename = await uploadImage(file)
       setI2iImage(filename)
     } catch (err) {
       console.error('[CreateView] I2I image upload failed:', err)
+      setError(err instanceof Error ? err.message : String(err))
     }
     setI2iUploading(false)
   }

--- a/src/components/models/DiscoverModels.tsx
+++ b/src/components/models/DiscoverModels.tsx
@@ -523,32 +523,9 @@ export function DiscoverModels({ category }: Props) {
     }
     if (!model.downloadUrl || !model.filename) return
 
-    // HF GGUF: which backend will actually consume this file?
-    //   - LM Studio explicitly enabled (openai provider with LM Studio name)
-    //     → nest under <user>/<repo>/ so its scanner picks it up.
-    //   - Otherwise default to Ollama (always-on by default), pull via
-    //     /api/pull as `hf.co/<user>/<repo>:<quant>`.
-    // Why: a raw .gguf in `~/.ollama/models` or in `~/.lmstudio/models/`
-    // (top-level) is silently ignored by both runtimes. That mismatch is
-    // the bug behind the "downloaded model never appears" reports.
     const lmStudioOn = !!providers.openai?.enabled && (providers.openai?.name || '').toLowerCase().includes('lm studio')
     const ollamaOn = !!providers.ollama?.enabled
-    const useOllamaPath = !lmStudioOn && ollamaOn
-
-    if (useOllamaPath) {
-      const ref = hfUrlToOllamaRef(model.downloadUrl, model.filename)
-      if (!ref) {
-        setInstallError(`Cannot map ${model.name} to an Ollama HF reference — try LM Studio.`)
-        return
-      }
-      try {
-        await pullModel(ref)
-      } catch (e) {
-        console.error('Ollama HF pull failed:', e)
-        setInstallError(`Ollama pull failed: ${e instanceof Error ? e.message : String(e)}. Is Ollama running?`)
-      }
-      return
-    }
+    const useOllamaImport = !lmStudioOn && ollamaOn
 
     const destDir = hfModelPath || (await detectProviderModelPath(providers.openai?.name || 'LM Studio'))
     if (!destDir) {
@@ -559,8 +536,19 @@ export function DiscoverModels({ category }: Props) {
 
     const subdir = hfUrlToLmStudioSubdir(model.downloadUrl)
     const targetDir = subdir ? `${destDir}/${subdir}` : destDir
+
     try {
-      dlStore.getState().setMeta(model.filename, model.downloadUrl, 'gguf', targetDir)
+      if (useOllamaImport) {
+        const ref = hfUrlToOllamaRef(model.downloadUrl, model.filename)
+        if (!ref) {
+          setInstallError(`Cannot map ${model.name} to an Ollama HF reference.`)
+          return
+        }
+        dlStore.getState().setMeta(model.filename, model.downloadUrl, 'gguf', targetDir, true, ref)
+      } else {
+        dlStore.getState().setMeta(model.filename, model.downloadUrl, 'gguf', targetDir, false)
+      }
+
       const expectedBytes = model.sizeGB ? Math.round(model.sizeGB * 1_073_741_824) : undefined
       await startModelDownloadToPath(model.downloadUrl, targetDir, model.filename, expectedBytes)
       dlStore.getState().startPolling()

--- a/src/components/models/DiscoverModels.tsx
+++ b/src/components/models/DiscoverModels.tsx
@@ -12,7 +12,7 @@ import {
   type DiscoverModel, type DownloadProgress, type ModelBundle, type CivitAIModelResult,
 } from '../../api/discover'
 import { getSystemVRAM } from '../../api/comfyui'
-import { openExternal } from '../../api/backend'
+import { openExternal, backendCall } from '../../api/backend'
 import { useModels } from '../../hooks/useModels'
 import { useDownloadStore } from '../../stores/downloadStore'
 import { useProviderStore } from '../../stores/providerStore'
@@ -208,6 +208,50 @@ export function DiscoverModels({ category }: Props) {
     return () => window.removeEventListener('comfyui-model-downloaded', handler)
   }, [category])
 
+  // Check which GGUF text models are REALLY downloaded to the provider directory
+  const [ggufStatuses, setGgufStatuses] = useState<Record<string, boolean>>({})
+  const refreshGgufStatuses = () => {
+    if (category !== 'text') return
+    const textModels = [...getUncensoredTextModels(), ...getMainstreamTextModels()]
+    const baseDir = hfModelPath || hfOverride?.trim()
+    if (!baseDir) return
+
+    const checkFiles = textModels
+      .filter(m => m.filename && m.downloadUrl)
+      .map(m => {
+        const subdir = hfUrlToLmStudioSubdir(m.downloadUrl!)
+        const targetDir = subdir ? `${baseDir}/${subdir}` : baseDir
+        const expectedBytes = m.sizeGB ? Math.round(m.sizeGB * 1_073_741_824) : 0
+        return {
+          destDir: targetDir,
+          filename: m.filename!,
+          expectedBytes,
+        }
+      })
+
+    if (checkFiles.length === 0) return
+
+    backendCall('check_model_sizes', { files: checkFiles })
+      .then((results: any[]) => {
+        const statuses: Record<string, boolean> = {}
+        for (const r of results) {
+          statuses[r.filename] = r.complete
+        }
+        setGgufStatuses(statuses)
+      })
+      .catch(() => {})
+  }
+
+  useEffect(() => {
+    refreshGgufStatuses()
+  }, [category, hfModelPath, hfOverride])
+
+  useEffect(() => {
+    const handler = () => refreshGgufStatuses()
+    window.addEventListener('comfyui-model-downloaded', handler)
+    return () => window.removeEventListener('comfyui-model-downloaded', handler)
+  }, [category, hfModelPath, hfOverride])
+
   // Start polling on mount if there are active downloads
   useEffect(() => {
     dlStore.getState().refresh()
@@ -281,6 +325,8 @@ export function DiscoverModels({ category }: Props) {
   // signal as the fastest-path (no fetchModels round-trip needed).
   const isModelFullyInstalled = (model: DiscoverModel) => {
     if (model.filename && downloads[model.filename]?.status === 'complete') return true
+
+    if (model.filename && ggufStatuses[model.filename]) return true
 
     const installedOllamaTags = installedModels
       .filter(m => m.provider === 'ollama')

--- a/src/hooks/useModels.ts
+++ b/src/hooks/useModels.ts
@@ -133,12 +133,21 @@ export function useModels() {
       // Dev mode: streaming fetch
       try {
         const response = await pullModelApi(name, controller.signal)
+        let streamError = null
         for await (const chunk of parseNDJSONStream<PullProgress>(response)) {
           updatePullProgress(name, chunk)
+          if (chunk.error) {
+            streamError = chunk.error
+            break
+          }
         }
-        completePull(name)
-        try { await fetchModels() } catch { /* non-critical */ }
-        setTimeout(() => dismissPull(name), 5000)
+        if (streamError) {
+          updatePullProgress(name, { status: `Error: ${streamError}` })
+        } else {
+          completePull(name)
+          try { await fetchModels() } catch { /* non-critical */ }
+          setTimeout(() => dismissPull(name), 5000)
+        }
       } catch (err) {
         if ((err as Error).name !== 'AbortError') {
           updatePullProgress(name, { status: `Error: ${(err as Error).message}` })

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { persist, createJSONStorage } from 'zustand/middleware'
 import { v4 as uuid } from 'uuid'
 import type { Conversation, Message } from '../types/chat'
 import type { AgentBlock } from '../types/agent-mode'
@@ -207,7 +207,7 @@ export const useChatStore = create<ChatState>()(
     }),
     {
       name: 'chat-conversations',
-      storage: createSafeStorage(),
+      storage: createJSONStorage(() => createSafeStorage()),
       // Phase 1 (v2.4.0) — rehydrate legacy singular `toolCall` into `toolCalls[]`.
       // Persisted shape is whatever was last written; migration runs on every load
       // and is idempotent, so version bumps are not required.

--- a/src/stores/downloadStore.ts
+++ b/src/stores/downloadStore.ts
@@ -55,8 +55,9 @@ export const useDownloadStore = create<DownloadStoreState>()((set, get) => ({
           const meta = get().downloadMeta[id]
           if (meta?.importToOllama && meta.ollamaRef && meta.destDir && !importing[id]) {
             set(s => ({ importing: { ...s.importing, [id]: true } }))
-            const { join } = require('path')
-            const ggufPath = join(meta.destDir, id)
+            const isWin = meta.destDir.includes('\\')
+            const sep = isWin ? '\\' : '/'
+            const ggufPath = meta.destDir.endsWith(sep) ? `${meta.destDir}${id}` : `${meta.destDir}${sep}${id}`
             createOllamaModel(meta.ollamaRef, `FROM "${ggufPath}"`)
               .then(() => {
                 set(s => {

--- a/src/stores/downloadStore.ts
+++ b/src/stores/downloadStore.ts
@@ -1,20 +1,22 @@
 import { create } from 'zustand'
 import { getDownloadProgress, pauseDownload, cancelDownload, resumeDownload, startModelDownload, startModelDownloadToPath, lookupFileMeta, type DownloadProgress } from '../api/discover'
+import { createOllamaModel } from '../api/ollama'
 
 // Maps filename → bundle name for grouped display
 type BundleMap = Record<string, string>
 
 interface DownloadStoreState {
   downloads: Record<string, DownloadProgress>
-  downloadMeta: Record<string, { url: string; subfolder: string; destDir?: string }>
+  downloadMeta: Record<string, { url: string; subfolder: string; destDir?: string; importToOllama?: boolean; ollamaRef?: string }>
   bundleMap: BundleMap  // filename → bundle name
+  importing: Record<string, boolean>
   polling: boolean
   pollInterval: ReturnType<typeof setInterval> | null
 
   refresh: () => Promise<void>
   startPolling: () => void
   stopPolling: () => void
-  setMeta: (filename: string, url: string, subfolder: string, destDir?: string) => void
+  setMeta: (filename: string, url: string, subfolder: string, destDir?: string, importToOllama?: boolean, ollamaRef?: string) => void
   setBundleGroup: (bundleName: string, filenames: string[]) => void
   markComplete: (filename: string) => void
   pause: (id: string) => Promise<void>
@@ -35,6 +37,7 @@ export const useDownloadStore = create<DownloadStoreState>()((set, get) => ({
   downloads: {},
   downloadMeta: {},
   bundleMap: {},
+  importing: {},
   polling: false,
   pollInterval: null,
 
@@ -44,20 +47,67 @@ export const useDownloadStore = create<DownloadStoreState>()((set, get) => ({
     try {
       const prog = await getDownloadProgress()
       const prev = get().downloads
+      const importing = get().importing
 
       // Detect newly completed downloads and dispatch event
       for (const [id, d] of Object.entries(prog)) {
         if (d.status === 'complete' && prev[id]?.status !== 'complete') {
-          window.dispatchEvent(new CustomEvent('comfyui-model-downloaded'))
+          const meta = get().downloadMeta[id]
+          if (meta?.importToOllama && meta.ollamaRef && meta.destDir && !importing[id]) {
+            set(s => ({ importing: { ...s.importing, [id]: true } }))
+            const { join } = require('path')
+            const ggufPath = join(meta.destDir, id)
+            createOllamaModel(meta.ollamaRef, `FROM "${ggufPath}"`)
+              .then(() => {
+                set(s => {
+                  const updatedImporting = { ...s.importing }
+                  delete updatedImporting[id]
+                  return { importing: updatedImporting }
+                })
+                get().markComplete(id)
+                window.dispatchEvent(new CustomEvent('comfyui-model-downloaded'))
+                window.dispatchEvent(new CustomEvent('lu-models-refresh'))
+              })
+              .catch((err) => {
+                set(s => {
+                  const updatedImporting = { ...s.importing }
+                  delete updatedImporting[id]
+                  return {
+                    importing: updatedImporting,
+                    downloads: {
+                      ...s.downloads,
+                      [id]: { progress: 1, total: 1, speed: 0, filename: id, status: 'error', error: `Ollama Import Failed: ${err.message}` }
+                    }
+                  }
+                })
+              })
+          } else if (!meta?.importToOllama) {
+            window.dispatchEvent(new CustomEvent('comfyui-model-downloaded'))
+          }
         }
       }
 
       const count = get().pollCount + 1
-      set({ downloads: prog, pollCount: count })
+      const mappedProg: Record<string, DownloadProgress> = {}
+      for (const [key, val] of Object.entries(prog)) {
+        if (importing[key]) {
+          mappedProg[key] = {
+            progress: 1,
+            total: 1,
+            speed: 0,
+            filename: key,
+            status: 'connecting',
+            error: undefined
+          }
+        } else {
+          mappedProg[key] = val
+        }
+      }
+      set({ downloads: mappedProg, pollCount: count })
 
       // Auto-stop polling when no active downloads
       // BUT wait at least 5 polls before stopping — gives Rust time to register new downloads
-      const hasActive = Object.values(prog).some(d =>
+      const hasActive = Object.values(mappedProg).some(d =>
         d.status === 'downloading' || d.status === 'connecting' || d.status === 'pausing'
       )
       if (!hasActive && count >= 5) {
@@ -83,8 +133,8 @@ export const useDownloadStore = create<DownloadStoreState>()((set, get) => ({
     set({ polling: false, pollInterval: null })
   },
 
-  setMeta: (filename, url, subfolder, destDir?) => {
-    set(s => ({ downloadMeta: { ...s.downloadMeta, [filename]: { url, subfolder, destDir } } }))
+  setMeta: (filename, url, subfolder, destDir?, importToOllama?, ollamaRef?) => {
+    set(s => ({ downloadMeta: { ...s.downloadMeta, [filename]: { url, subfolder, destDir, importToOllama, ollamaRef } } }))
   },
 
   setBundleGroup: (bundleName, filenames) => {

--- a/src/stores/memoryStore.ts
+++ b/src/stores/memoryStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { persist, createJSONStorage } from 'zustand/middleware'
 import { v4 as uuid } from 'uuid'
 import type { MemoryEntry, MemoryCategory, MemoryFile, MemoryType, MemorySettings } from '../types/agent-mode'
 import { MEMORY_MIGRATION_MAP, MEMORY_BUDGET_TIERS } from '../types/agent-mode'
@@ -410,7 +410,7 @@ export const useMemoryStore = create<MemoryState>()(
     {
       name: 'locally-uncensored-memory',
       version: 2,
-      storage: createSafeStorage(),
+      storage: createJSONStorage(() => createSafeStorage()),
       migrate: (persistedState, version) => {
         if (version < 2) {
           return migrateV1toV2(persistedState)

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -77,6 +77,7 @@ export interface PullProgress {
   digest?: string
   total?: number
   completed?: number
+  error?: string
 }
 
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -93,14 +93,30 @@ function comfyLauncher(): Plugin {
   let comfyProcess: ChildProcess | null = null
   let comfyLogs: string[] = []
 
+  const getComfyPython = (comfyPath: string): string => {
+    const isWin = process.platform === 'win32'
+    const venvPaths = isWin
+      ? [join(comfyPath, '.venv', 'Scripts', 'python.exe'), join(comfyPath, 'venv', 'Scripts', 'python.exe')]
+      : [join(comfyPath, '.venv', 'bin', 'python'), join(comfyPath, 'venv', 'bin', 'python')]
+    
+    for (const vp of venvPaths) {
+      if (existsSync(vp)) {
+        console.log(`[ComfyUI] Found virtual environment python: ${vp}`)
+        return vp
+      }
+    }
+    return pythonBin
+  }
+
   const startComfy = (comfyPath: string): { status: string; path: string } => {
     if (comfyProcess && !comfyProcess.killed) {
       return { status: 'already_running', path: comfyPath }
     }
 
     comfyLogs = []
-    console.log(`[ComfyUI] Spawning ${pythonBin} in: ${comfyPath}`)
-    comfyProcess = spawn(pythonBin, ['main.py', '--listen', '127.0.0.1', '--port', '8188'], {
+    const executable = getComfyPython(comfyPath)
+    console.log(`[ComfyUI] Spawning ${executable} in: ${comfyPath}`)
+    comfyProcess = spawn(executable, ['main.py', '--listen', '127.0.0.1', '--port', '8188'], {
       cwd: comfyPath,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: false,
@@ -168,8 +184,14 @@ function comfyLauncher(): Plugin {
         // 3. Strict Origin Validation (Defense in Depth)
         const origin = req.headers.origin;
         if (origin) {
-            const allowedOrigins = ['http://localhost:5173', 'http://127.0.0.1:5173', 'tauri://localhost', 'http://tauri.localhost'];
-            if (!allowedOrigins.includes(origin)) {
+            const host = req.headers.host;
+            const allowedOrigins = ['tauri://localhost', 'http://tauri.localhost'];
+            if (host) {
+                allowedOrigins.push(`http://${host}`);
+                allowedOrigins.push(`https://${host}`);
+            }
+            const isLocalOrigin = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+            if (!allowedOrigins.includes(origin) && !isLocalOrigin) {
                 res.writeHead(403, { 'Content-Type': 'text/plain' });
                 res.end('Forbidden: Invalid Origin (CSRF Protection)');
                 return;
@@ -400,30 +422,48 @@ function comfyLauncher(): Plugin {
           const filename = basename(destPath)
           activeDownloads.set(id, { progress: 0, total: 0, speed: 0, filename, status: 'connecting' })
 
+          const { existsSync, statSync, createWriteStream, mkdirSync } = require('fs')
+
           const doRequest = (requestUrl: string, redirectCount = 0) => {
             if (redirectCount > 5) { promiseReject(new Error('Too many redirects')); return }
+            
+            let existingSize = 0
+            const headers: Record<string, string> = { 'User-Agent': 'LocallyUncensored/1.1' }
+            
+            if (existsSync(destPath)) {
+              try {
+                existingSize = statSync(destPath).size
+                if (existingSize > 0) {
+                  headers['Range'] = `bytes=${existingSize}-`
+                }
+              } catch {}
+            }
+
             const proto = requestUrl.startsWith('https') ? https : http
-            proto.get(requestUrl, { headers: { 'User-Agent': 'LocallyUncensored/1.1' } }, (response) => {
+            proto.get(requestUrl, { headers }, (response) => {
               if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
                 doRequest(response.headers.location, redirectCount + 1)
                 return
               }
-              if (response.statusCode !== 200) {
+              
+              const isPartial = response.statusCode === 206
+              if (response.statusCode !== 200 && !isPartial) {
                 activeDownloads.set(id, { ...activeDownloads.get(id)!, status: 'error', error: `HTTP ${response.statusCode}` })
                 promiseReject(new Error(`HTTP ${response.statusCode}`))
                 return
               }
 
-              const total = parseInt(response.headers['content-length'] || '0', 10)
-              let downloaded = 0
+              const contentLength = parseInt(response.headers['content-length'] || '0', 10)
+              const totalBytes = isPartial ? (contentLength + existingSize) : contentLength
+              let downloaded = isPartial ? existingSize : 0
               let lastTime = Date.now()
-              let lastBytes = 0
+              let lastBytes = downloaded
 
               const dir = dirname(destPath)
               if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-              const file = createWriteStream(destPath)
+              const file = createWriteStream(destPath, { flags: isPartial ? 'a' : 'w' })
 
-              activeDownloads.set(id, { progress: 0, total, speed: 0, filename, status: 'downloading' })
+              activeDownloads.set(id, { progress: downloaded, total: totalBytes, speed: 0, filename, status: 'downloading' })
 
               response.on('data', (chunk: Buffer) => {
                 downloaded += chunk.length
@@ -433,14 +473,14 @@ function comfyLauncher(): Plugin {
                   const speed = (downloaded - lastBytes) / dt
                   lastTime = now
                   lastBytes = downloaded
-                  activeDownloads.set(id, { progress: downloaded, total, speed, filename, status: 'downloading' })
+                  activeDownloads.set(id, { progress: downloaded, total: totalBytes, speed, filename, status: 'downloading' })
                 }
               })
 
               response.pipe(file)
               file.on('finish', () => {
                 file.close()
-                activeDownloads.set(id, { progress: total || downloaded, total: total || downloaded, speed: 0, filename, status: 'complete' })
+                activeDownloads.set(id, { progress: totalBytes || downloaded, total: totalBytes || downloaded, speed: 0, filename, status: 'complete' })
                 console.log(`[Download] Complete: ${filename}`)
                 promiseResolve()
               })
@@ -575,13 +615,7 @@ function comfyLauncher(): Plugin {
             const { existsSync, statSync } = require('fs')
             const { join } = require('path')
             const home = require('os').homedir()
-            // Try to find ComfyUI path
-            const candidates = [
-              join(home, 'ComfyUI'),
-              join(home, 'Desktop', 'ComfyUI'),
-              'C:\\ComfyUI',
-            ]
-            const comfyPath = candidates.find(p => existsSync(p)) || join(home, 'ComfyUI')
+            const comfyPath = findComfyUI() || join(home, 'ComfyUI')
             const results = (files as any[]).map((f: any) => {
               const subfolder = f.subfolder || ''
               const dir = subfolder.startsWith('custom_nodes')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -543,6 +543,12 @@ function comfyLauncher(): Plugin {
             }
 
             const id = filename
+            const active = activeDownloads.get(id)
+            if (active && (active.status === 'downloading' || active.status === 'connecting')) {
+              res.writeHead(200, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ status: 'started', id }))
+              return
+            }
             console.log(`[Download] Starting: ${filename} → ${destDir}`)
             downloadFile(url, destPath, id).catch(err => console.error(`[Download] Failed: ${err.message}`))
 
@@ -675,6 +681,12 @@ function comfyLauncher(): Plugin {
               }
             }
             const id = filename
+            const active = activeDownloads.get(id)
+            if (active && (active.status === 'downloading' || active.status === 'connecting')) {
+              res.writeHead(200, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ status: 'started', id }))
+              return
+            }
             console.log(`[Download] Starting to path: ${filename} → ${destDir}`)
             downloadFile(url, destPath, id).catch(err => console.error(`[Download] Failed: ${err.message}`))
             res.writeHead(200, { 'Content-Type': 'application/json' })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -623,11 +623,16 @@ function comfyLauncher(): Plugin {
             const home = require('os').homedir()
             const comfyPath = findComfyUI() || join(home, 'ComfyUI')
             const results = (files as any[]).map((f: any) => {
-              const subfolder = f.subfolder || ''
-              const dir = subfolder.startsWith('custom_nodes')
-                ? join(comfyPath, subfolder)
-                : join(comfyPath, 'models', subfolder)
-              const filePath = join(dir, f.filename)
+              let filePath = ''
+              if (f.destDir) {
+                filePath = join(f.destDir, f.filename)
+              } else {
+                const subfolder = f.subfolder || ''
+                const dir = subfolder.startsWith('custom_nodes')
+                  ? join(comfyPath, subfolder)
+                  : join(comfyPath, 'models', subfolder)
+                filePath = join(dir, f.filename)
+              }
               if (existsSync(filePath)) {
                 const actual = statSync(filePath).size
                 const threshold = f.expectedBytes > 0 ? f.expectedBytes * 0.9 : 0

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -252,23 +252,24 @@ function comfyLauncher(): Plugin {
       server.middlewares.use('/comfyui', (req, res, next) => {
         if (req.method !== 'POST') return next()
         const targetPath = (req.url || '').replace(/^\/comfyui/, '') || '/'
-        let body = ''
-        req.on('data', (chunk: any) => { body += chunk })
+        const chunks: Buffer[] = []
+        req.on('data', (chunk: Buffer) => { chunks.push(chunk) })
         req.on('end', () => {
+          const body = Buffer.concat(chunks)
+          const headers = { ...req.headers }
+          delete headers.host
           const proxyReq = http.request({
             hostname: '127.0.0.1',
             port: 8188,
             path: targetPath,
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers,
           }, (proxyRes) => {
-            const chunks: Buffer[] = []
-            proxyRes.on('data', (c: Buffer) => chunks.push(c))
+            const resChunks: Buffer[] = []
+            proxyRes.on('data', (c: Buffer) => resChunks.push(c))
             proxyRes.on('end', () => {
-              const responseBody = Buffer.concat(chunks).toString()
-              res.writeHead(proxyRes.statusCode || 500, {
-                'Content-Type': proxyRes.headers['content-type'] || 'application/json',
-              })
+              const responseBody = Buffer.concat(resChunks)
+              res.writeHead(proxyRes.statusCode || 500, proxyRes.headers)
               res.end(responseBody)
             })
           })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -116,7 +116,7 @@ function comfyLauncher(): Plugin {
     comfyLogs = []
     const executable = getComfyPython(comfyPath)
     console.log(`[ComfyUI] Spawning ${executable} in: ${comfyPath}`)
-    comfyProcess = spawn(executable, ['main.py', '--listen', '127.0.0.1', '--port', '8188'], {
+    comfyProcess = spawn(executable, ['main.py', '--listen', '127.0.0.1', '--port', '8188', '--enable-cors-header', '*'], {
       cwd: comfyPath,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: false,


### PR DESCRIPTION
Fixes #51.

This PR addresses:
1. **Origin Check Failure (HTTP 403)**: Dynamic resolution of loopback origin header so setting comfy path works when Vite runs on custom ports.
2. **Virtualenv Python Support**: Automatic detection of Python interpreters inside ComfyUI's virtual environment folder (`.venv` or `venv`) on macOS, Linux, and Windows to prevent traceback crashes.
3. **Download Resuming**: Implemented support for HTTP Range headers in the model download proxy server.
4. **Fuzzy Fallback complete filter**: Filter out partial/incomplete files in the `checkBundlesInstalled` fallback loop to prevent them from showing as `INSTALLED` in the Discover/Model Manager views. It also updates `check-model-sizes` to query the correct user-set path.