### PR TITLE
fix: display remote-ComfyUI gallery media via Rust proxy

### DIFF
--- a/src/components/create/experimental/CreatePanel.tsx
+++ b/src/components/create/experimental/CreatePanel.tsx
@@ -1,8 +1,9 @@
 import { motion, AnimatePresence } from 'framer-motion'
 import { Images, Play, PanelRightClose, PanelRightOpen, Trash2, Download, MonitorOff } from 'lucide-react'
 import { downloadMediaUrl } from '../../../lib/download-media'
-import { useCreateStore } from '../../../stores/createStore'
-import { galleryItemUrl, markGalleryItemAvailable, recoverGalleryUrl } from './galleryUrl'
+import { useCreateStore, type GalleryItem } from '../../../stores/createStore'
+import { markGalleryItemAvailable, recoverGalleryUrl, revokeGalleryBlob } from './galleryUrl'
+import { useResolvedMediaUrl } from './useResolvedMediaUrl'
 import { cn } from '../ui/cn'
 
 interface Props {
@@ -10,6 +11,61 @@ interface Props {
   onOpenChange: (open: boolean) => void
   activeId: string | null
   onSelect: (id: string) => void
+}
+
+/** One gallery thumbnail. A component (not inline JSX) so useResolvedMediaUrl —
+ *  which proxies remote-ComfyUI media into a blob: URL — can run per item; hooks
+ *  can't be called inside a .map callback. */
+function GalleryTile({ g, active, onSelect, onRemove }: {
+  g: GalleryItem
+  active: boolean
+  onSelect: (id: string) => void
+  onRemove: (id: string) => void
+}) {
+  const url = useResolvedMediaUrl(g)
+  return (
+    <div className="relative group">
+      <button
+        onClick={() => onSelect(g.id)}
+        className={cn(
+          'w-full aspect-square rounded-lg overflow-hidden border-2 transition-colors relative',
+          active ? 'border-white/60' : 'border-transparent hover:border-white/20',
+          g.intent === 'removebg' && 'lu-checker',
+        )}
+      >
+        {g.type === 'video' ? (
+          <>
+            <video src={url} muted playsInline onError={() => recoverGalleryUrl(g)} onLoadedData={() => markGalleryItemAvailable(g)} className="w-full h-full object-cover" />
+            <span className="absolute inset-0 flex items-center justify-center bg-black/20"><Play size={16} className="text-white/90" /></span>
+          </>
+        ) : (
+          <img src={url} alt="" onError={() => recoverGalleryUrl(g)} onLoad={() => markGalleryItemAvailable(g)} className="w-full h-full object-cover" />
+        )}
+        {g.unavailable && (
+          <span
+            className="absolute inset-0 flex items-center justify-center bg-black/50 text-gray-500"
+            title="Local render — the local engine isn't reachable"
+          >
+            <MonitorOff size={16} />
+          </span>
+        )}
+      </button>
+      <button
+        onClick={() => onRemove(g.id)}
+        className="absolute -top-1.5 -right-1.5 w-6 h-6 rounded-full bg-red-600/90 hover:bg-red-600 text-gray-100 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center shadow-sm"
+        title="Delete"
+      >
+        <Trash2 size={12} />
+      </button>
+      <button
+        onClick={() => { void downloadMediaUrl(url, g.filename || undefined) }}
+        className="absolute bottom-1 right-1 w-6 h-6 rounded-md bg-black/55 hover:bg-black/70 text-gray-100 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center shadow-sm"
+        title="Download"
+      >
+        <Download size={12} />
+      </button>
+    </div>
+  )
 }
 
 /**
@@ -22,6 +78,10 @@ export function CreatePanel({ open, onOpenChange, activeId, onSelect }: Props) {
   const gallery = useCreateStore((s) => s.gallery)
   const removeFromGallery = useCreateStore((s) => s.removeFromGallery)
   const count = gallery.length
+
+  // Revoke any proxied blob: URL before dropping the item, so a long session
+  // doesn't leak object URLs for deleted remote-ComfyUI renders.
+  const handleRemove = (id: string) => { revokeGalleryBlob(id); removeFromGallery(id) }
 
   const bubble =
     'my-2 mr-2 rounded-xl bg-gray-50 dark:bg-[#1e1e1e] ring-1 ring-black/[0.04] dark:ring-white/[0.05] flex flex-col overflow-hidden shrink-0'
@@ -87,47 +147,13 @@ export function CreatePanel({ open, onOpenChange, activeId, onSelect }: Props) {
             ) : (
               <div className="grid grid-cols-2 gap-2">
                 {gallery.map((g) => (
-                  <div key={g.id} className="relative group">
-                    <button
-                      onClick={() => onSelect(g.id)}
-                      className={cn(
-                        'w-full aspect-square rounded-lg overflow-hidden border-2 transition-colors relative',
-                        (activeId ?? gallery[0]?.id) === g.id ? 'border-white/60' : 'border-transparent hover:border-white/20',
-                        g.intent === 'removebg' && 'lu-checker',
-                      )}
-                    >
-                      {g.type === 'video' ? (
-                        <>
-                          <video src={galleryItemUrl(g)} muted playsInline onError={() => recoverGalleryUrl(g)} onLoadedData={() => markGalleryItemAvailable(g)} className="w-full h-full object-cover" />
-                          <span className="absolute inset-0 flex items-center justify-center bg-black/20"><Play size={16} className="text-white/90" /></span>
-                        </>
-                      ) : (
-                        <img src={galleryItemUrl(g)} alt="" onError={() => recoverGalleryUrl(g)} onLoad={() => markGalleryItemAvailable(g)} className="w-full h-full object-cover" />
-                      )}
-                      {g.unavailable && (
-                        <span
-                          className="absolute inset-0 flex items-center justify-center bg-black/50 text-gray-500"
-                          title="Local render — the local engine isn't reachable"
-                        >
-                          <MonitorOff size={16} />
-                        </span>
-                      )}
-                    </button>
-                    <button
-                      onClick={() => removeFromGallery(g.id)}
-                      className="absolute -top-1.5 -right-1.5 w-6 h-6 rounded-full bg-red-600/90 hover:bg-red-600 text-gray-100 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center shadow-sm"
-                      title="Delete"
-                    >
-                      <Trash2 size={12} />
-                    </button>
-                    <button
-                      onClick={() => { void downloadMediaUrl(galleryItemUrl(g), g.filename || undefined) }}
-                      className="absolute bottom-1 right-1 w-6 h-6 rounded-md bg-black/55 hover:bg-black/70 text-gray-100 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center shadow-sm"
-                      title="Download"
-                    >
-                      <Download size={12} />
-                    </button>
-                  </div>
+                  <GalleryTile
+                    key={g.id}
+                    g={g}
+                    active={(activeId ?? gallery[0]?.id) === g.id}
+                    onSelect={onSelect}
+                    onRemove={handleRemove}
+                  />
                 ))}
               </div>
             )}

--- a/src/components/create/experimental/OutputView.tsx
+++ b/src/components/create/experimental/OutputView.tsx
@@ -3,7 +3,8 @@ import { Cpu, Sparkles, ImageDown, Maximize2, Download, Wand2, MonitorOff } from
 import { useCreateStore, type GalleryItem, type ProgressPhase } from '../../../stores/createStore'
 import { downloadComfyFile, isTauri } from '../../../api/backend'
 import { refreshResultUrl } from '../../../api/cloud/jobs'
-import { galleryItemUrl, markGalleryItemAvailable, recoverGalleryUrl } from './galleryUrl'
+import { markGalleryItemAvailable, recoverGalleryUrl } from './galleryUrl'
+import { useResolvedMediaUrl } from './useResolvedMediaUrl'
 import { cn } from '../ui/cn'
 
 function phaseIcon(phase: ProgressPhase) {
@@ -139,7 +140,7 @@ function reconcileDims(item: GalleryItem, w: number, h: number) {
 }
 
 export function ResultView({ item, onFullscreen, onSendToEditor }: ResultProps) {
-  const url = galleryItemUrl(item)
+  const url = useResolvedMediaUrl(item)
   const download = () => void downloadGalleryItem(item)
   const isVideo = item.type === 'video'
   return (

--- a/src/components/create/experimental/galleryUrl.ts
+++ b/src/components/create/experimental/galleryUrl.ts
@@ -1,4 +1,5 @@
 import { getImageUrl } from '../../../api/comfyui'
+import { fetchLocalhostBytes, isComfyLocal, isTauri } from '../../../api/backend'
 import { refreshResultUrl } from '../../../api/cloud/jobs'
 import { useCreateStore, type GalleryItem } from '../../../stores/createStore'
 
@@ -7,6 +8,68 @@ import { useCreateStore, type GalleryItem } from '../../../stores/createStore'
  *  → ComfyUI /view path (filename/subfolder). */
 export function galleryItemUrl(item: GalleryItem): string {
   return item.remoteUrl ?? item.dataUrl ?? getImageUrl(item.filename, item.subfolder)
+}
+
+// ── Remote-ComfyUI media resolution ────────────────────────────────────────
+// The WebView CSP (tauri.conf.json) only whitelists localhost/127.0.0.1 for
+// img-src/media-src, so an <img>/<video> src pointed at a user-configured
+// REMOTE ComfyUI host (LAN IP, Tailscale, homelab) is blocked before the
+// request leaves the app — even though generation and downloads work, because
+// those go through the Rust IPC proxy (proxy_localhost_stream), which CSP does
+// not gate. The fix: pull the bytes through that same proxy (fetchLocalhostBytes)
+// and hand the WebView a blob: URL, which the CSP already allows. No CSP change.
+//
+// item.id → live object URL. Kept in-memory; revoke via revokeGalleryBlob when
+// an item leaves the gallery so a long session doesn't leak blob URLs.
+const blobCache = new Map<string, string>()
+// item.id → in-flight fetch, so concurrent renders don't refetch the same item.
+const blobInflight = new Map<string, Promise<string>>()
+
+/** True for a remote-ComfyUI item that must be proxied to display: Tauri, a
+ *  non-local host, a real /view file, and no cloud/in-memory URL already set. */
+export function needsProxyResolve(item: GalleryItem): boolean {
+  return isTauri() && !isComfyLocal() && !!item.filename && !item.remoteUrl && !item.dataUrl
+}
+
+/** Synchronously read an already-resolved blob URL (empty string if none). */
+export function getCachedGalleryBlob(id: string): string {
+  return blobCache.get(id) ?? ''
+}
+
+/** Fetch a remote-ComfyUI item's bytes through the Rust proxy and cache a
+ *  blob: URL for it. Marks the item available on success; on failure delegates
+ *  to recoverGalleryUrl (flags `unavailable` — the honest "engine unreachable"
+ *  signal here) and rethrows. */
+export function resolveGalleryBlobUrl(item: GalleryItem): Promise<string> {
+  const cached = blobCache.get(item.id)
+  if (cached) return Promise.resolve(cached)
+  const pending = blobInflight.get(item.id)
+  if (pending) return pending
+  const p = (async () => {
+    try {
+      const bytes = await fetchLocalhostBytes(getImageUrl(item.filename, item.subfolder))
+      const type = item.type === 'video' ? 'video/mp4' : 'image/png'
+      const url = URL.createObjectURL(new Blob([bytes], { type }))
+      blobCache.set(item.id, url)
+      markGalleryItemAvailable(item)
+      return url
+    } catch (err) {
+      recoverGalleryUrl(item)
+      throw err
+    } finally {
+      blobInflight.delete(item.id)
+    }
+  })()
+  blobInflight.set(item.id, p)
+  return p
+}
+
+/** Revoke and forget an item's cached blob URL (call when it leaves the gallery). */
+export function revokeGalleryBlob(id: string): void {
+  const url = blobCache.get(id)
+  if (url) URL.revokeObjectURL(url)
+  blobCache.delete(id)
+  blobInflight.delete(id)
 }
 
 // Cloud signed URLs expire ~1 h after the last read, so a persisted item's

--- a/src/components/create/experimental/useResolvedMediaUrl.ts
+++ b/src/components/create/experimental/useResolvedMediaUrl.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import type { GalleryItem } from '../../../stores/createStore'
+import { galleryItemUrl, getCachedGalleryBlob, needsProxyResolve, resolveGalleryBlobUrl } from './galleryUrl'
+
+/**
+ * Display URL for a gallery item, resolving remote-ComfyUI media through the
+ * Rust proxy into a CSP-allowed blob: URL (see galleryUrl.ts for the why).
+ *
+ * - Local ComfyUI / cloud (remoteUrl) / in-memory (dataUrl): returns
+ *   galleryItemUrl(item) synchronously — unchanged, already works today.
+ * - Remote ComfyUI: returns a cached blob URL, or '' until the proxy fetch
+ *   resolves (then re-renders with the blob URL). On failure the item is
+ *   flagged `unavailable` by resolveGalleryBlobUrl and this stays ''.
+ */
+export function useResolvedMediaUrl(item: GalleryItem): string {
+  const needsProxy = needsProxyResolve(item)
+  const [blobUrl, setBlobUrl] = useState<string>(() => (needsProxy ? getCachedGalleryBlob(item.id) : ''))
+
+  useEffect(() => {
+    if (!needsProxy) return
+    let cancelled = false
+    // resolveGalleryBlobUrl returns the cached blob URL immediately (as a
+    // resolved promise) if present, so this never refetches an already-resolved
+    // item; setState only fires in the async callback (never synchronously).
+    void resolveGalleryBlobUrl(item)
+      .then((url) => { if (!cancelled) setBlobUrl(url) })
+      .catch(() => { /* recoverGalleryUrl already flagged the item */ })
+    return () => { cancelled = true }
+  }, [needsProxy, item])
+
+  return needsProxy ? blobUrl : galleryItemUrl(item)
+}


### PR DESCRIPTION
Fixes #82

## Root cause

`src-tauri/tauri.conf.json`'s CSP hardcodes `img-src`/`media-src` to only
allow `localhost`/`127.0.0.1`. Any `<img>`/`<video>` `src` pointed at a
user-configured remote ComfyUI host (LAN IP, Tailscale, homelab — an
explicitly supported config per Settings' own copy) is blocked by the
WebView before the request leaves the app.

Generation and the Download button already work for remote hosts because
they route through the Rust IPC proxy (`invoke('proxy_localhost_stream', ...)`
in `src/api/backend.ts`), which CSP doesn't gate — only the direct
`<img>`/`<video>` tags in the gallery grid and fullscreen-adjacent inline
preview hit the CSP wall. That split is exactly what #82 reports: Download
succeeds, thumbnails don't, and the "local engine isn't reachable" message is
misleading since the engine is fully reachable.

## Fix

Route remote-host media bytes through the existing proxy
(`fetchLocalhostBytes`, already used by the vision-feedback loop) and hand
the WebView a `blob:` URL instead of the raw remote URL. `img-src`/`media-src`
already allow `blob:`, so **no CSP change is needed** — this is a
frontend-only change reusing infrastructure that's already shipped and
proven (the same proxy backs generation and Download today).

- `galleryUrl.ts`: `needsProxyResolve` / `resolveGalleryBlobUrl` (cached,
  in-flight-deduped, revoked via `revokeGalleryBlob` on item removal so a
  long session doesn't leak object URLs)
- `useResolvedMediaUrl` hook: returns the existing `galleryItemUrl()`
  synchronously for local ComfyUI / cloud / in-memory items (unchanged
  behavior), or the resolved `blob:` URL for remote-ComfyUI items
- Wired into `ResultView` (`OutputView.tsx`) and the gallery grid tile +
  Download button (`CreatePanel.tsx`, extracted into a `GalleryTile`
  component since hooks can't run inside `.map`)

## Known follow-ups (not in this PR)

- `Lightbox.tsx` (fullscreen preview), `Stage.tsx`, and
  `fetchGalleryItemBlob` (op-source adoption) also use `galleryItemUrl` and
  still hit the same CSP wall for remote hosts. The resolver added here is
  reusable, so wiring these in is a small follow-up if wanted.
- WebSocket live-progress (`comfyuiWsUrl`) is also CSP-blocked for remote
  hosts, but already has a polling fallback — separate issue, not addressed
  here.
- ComfyUI's own DNS-rebinding/Origin check can independently 403 a remote
  host even after this fix — that's server-side config (`--enable-cors-header`
  on the ComfyUI process), not something the client can work around.

## Testing

- `tsc --noEmit` and `eslint` clean on all touched files; no new
  project-wide lint violations (pre-existing baseline count unchanged).
- Manually verified end-to-end against a real remote ComfyUI instance (LAN,
  confirmed via the reporter's own repro in #82): generation, grid
  thumbnail, inline preview, and grid Download all now work without the CSP
  block. Confirmed via an unsigned CI-built installer (no code-signing
  secrets available on a fork) rather than a local Rust toolchain.