### PR TITLE
feat(create): add native HiRes generation

### DIFF
--- a/src/api/__tests__/hires-fix.test.ts
+++ b/src/api/__tests__/hires-fix.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyNativeHiresFix,
+  nativeHiresFinalSize,
+  NativeHiresFixError,
+} from '../hires-fix'
+
+const baseWorkflow = () => ({
+  '1': {
+    class_type: 'CheckpointLoaderSimple',
+    inputs: { ckpt_name: 'model.safetensors' },
+  },
+  '4': {
+    class_type: 'KSampler',
+    inputs: {
+      model: ['1', 0],
+      positive: ['2', 0],
+      negative: ['3', 0],
+      latent_image: ['8', 0],
+      seed: 123,
+      steps: 25,
+      cfg: 7,
+      sampler_name: 'dpmpp_2m',
+      scheduler: 'karras',
+      denoise: 1,
+    },
+  },
+  '5': {
+    class_type: 'VAEDecode',
+    inputs: { samples: ['4', 0], vae: ['1', 2] },
+  },
+  '6': {
+    class_type: 'SaveImage',
+    inputs: { images: ['5', 0], filename_prefix: 'LU' },
+  },
+  '8': {
+    class_type: 'EmptyLatentImage',
+    inputs: { width: 1216, height: 832, batch_size: 1 },
+  },
+})
+
+describe('nativeHiresFinalSize', () => {
+  it('produces the 1.5× 1216×832 target on the latent grid', () => {
+    expect(nativeHiresFinalSize(1216, 832, 1.5)).toEqual({
+      width: 1824,
+      height: 1248,
+    })
+  })
+
+  it('rejects output dimensions above the app limit', () => {
+    expect(() => nativeHiresFinalSize(4096, 4096, 1.5)).toThrow(/4096 px/)
+  })
+})
+
+describe('applyNativeHiresFix', () => {
+  it('inserts a latent upscale and native refinement sampler', () => {
+    const source = baseWorkflow()
+    const result = applyNativeHiresFix(source, {
+      baseWidth: 1216,
+      baseHeight: 832,
+      scale: 1.5,
+      denoise: 0.35,
+      steps: 12,
+      upscaleMethod: 'bislerp',
+    })
+
+    expect(result.width).toBe(1824)
+    expect(result.height).toBe(1248)
+    expect(result.workflow[result.upscaleNodeId]).toEqual(expect.objectContaining({
+      class_type: 'LatentUpscale',
+      inputs: {
+        samples: ['4', 0],
+        upscale_method: 'bislerp',
+        width: 1824,
+        height: 1248,
+        crop: 'disabled',
+      },
+    }))
+    expect(result.workflow[result.samplerNodeId]).toEqual(expect.objectContaining({
+      class_type: 'KSampler',
+      inputs: expect.objectContaining({
+        model: ['1', 0],
+        positive: ['2', 0],
+        negative: ['3', 0],
+        latent_image: [result.upscaleNodeId, 0],
+        seed: 123,
+        steps: 12,
+        cfg: 7,
+        sampler_name: 'dpmpp_2m',
+        scheduler: 'karras',
+        denoise: 0.35,
+      }),
+    }))
+    expect(result.workflow['5'].inputs.samples).toEqual([result.samplerNodeId, 0])
+
+    // The caller's freshly built graph remains untouched.
+    expect(source['5'].inputs.samples).toEqual(['4', 0])
+  })
+
+  it('supports a tiled final image decode', () => {
+    const workflow: Record<string, any> = baseWorkflow()
+    workflow['5'].class_type = 'VAEDecodeTiled'
+
+    const result = applyNativeHiresFix(workflow, {
+      baseWidth: 1024,
+      baseHeight: 1024,
+      scale: 1.25,
+      denoise: 0.3,
+      steps: 10,
+      upscaleMethod: 'bicubic',
+    })
+
+    expect(result.workflow['5'].inputs.samples).toEqual([result.samplerNodeId, 0])
+    expect(result).toEqual(expect.objectContaining({ width: 1280, height: 1280 }))
+  })
+
+  it('rejects workflows whose final decode is not fed by a core KSampler', () => {
+    const workflow: Record<string, any> = baseWorkflow()
+    workflow['4'].class_type = 'SamplerCustom'
+
+    expect(() => applyNativeHiresFix(workflow, {
+      baseWidth: 1024,
+      baseHeight: 1024,
+      scale: 1.5,
+      denoise: 0.35,
+      steps: 12,
+      upscaleMethod: 'bislerp',
+    })).toThrow(NativeHiresFixError)
+  })
+
+  it('rejects ambiguous multi-output image workflows', () => {
+    const workflow: Record<string, any> = baseWorkflow()
+    workflow['9'] = {
+      class_type: 'VAEDecode',
+      inputs: { samples: ['4', 0], vae: ['1', 2] },
+    }
+    workflow['10'] = {
+      class_type: 'SaveImage',
+      inputs: { images: ['9', 0], filename_prefix: 'second' },
+    }
+
+    expect(() => applyNativeHiresFix(workflow, {
+      baseWidth: 1024,
+      baseHeight: 1024,
+      scale: 1.5,
+      denoise: 0.35,
+      steps: 12,
+      upscaleMethod: 'bislerp',
+    })).toThrow(/multiple final image decode paths/)
+  })
+})

--- a/src/api/hires-fix.ts
+++ b/src/api/hires-fix.ts
@@ -1,0 +1,213 @@
+export type HiresUpscaleMethod =
+  | 'nearest-exact'
+  | 'bilinear'
+  | 'area'
+  | 'bicubic'
+  | 'bislerp'
+
+export interface NativeHiresFixOptions {
+  baseWidth: number
+  baseHeight: number
+  scale: number
+  denoise: number
+  steps: number
+  upscaleMethod: HiresUpscaleMethod
+}
+
+export interface NativeHiresFixResult {
+  workflow: Record<string, any>
+  width: number
+  height: number
+  upscaleNodeId: string
+  samplerNodeId: string
+}
+
+export class NativeHiresFixError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NativeHiresFixError'
+  }
+}
+
+const IMAGE_OUTPUT_NODES = new Set(['SaveImage', 'PreviewImage'])
+const IMAGE_DECODE_NODES = new Set(['VAEDecode', 'VAEDecodeTiled'])
+const UPSCALE_METHODS: ReadonlySet<HiresUpscaleMethod> = new Set([
+  'nearest-exact',
+  'bilinear',
+  'area',
+  'bicubic',
+  'bislerp',
+])
+
+function isNodeRef(value: unknown): value is [string, number] {
+  return Array.isArray(value)
+    && value.length >= 2
+    && (typeof value[0] === 'string' || typeof value[0] === 'number')
+    && typeof value[1] === 'number'
+}
+
+function cloneWorkflow(workflow: Record<string, any>): Record<string, any> {
+  if (typeof structuredClone === 'function') return structuredClone(workflow)
+  return JSON.parse(JSON.stringify(workflow)) as Record<string, any>
+}
+
+function nextNodeId(workflow: Record<string, any>): string {
+  let candidate = Object.keys(workflow).reduce((max, id) => {
+    const parsed = Number(id)
+    return Number.isInteger(parsed) && parsed >= 0 ? Math.max(max, parsed) : max
+  }, 0) + 1
+
+  while (String(candidate) in workflow) candidate++
+  return String(candidate)
+}
+
+function snapToLatentGrid(value: number): number {
+  return Math.max(64, Math.round(value / 8) * 8)
+}
+
+export function nativeHiresFinalSize(
+  baseWidth: number,
+  baseHeight: number,
+  scale: number,
+): { width: number; height: number } {
+  if (!Number.isFinite(baseWidth) || !Number.isFinite(baseHeight) || baseWidth < 64 || baseHeight < 64) {
+    throw new NativeHiresFixError('Native HiRes needs a valid base width and height of at least 64 px.')
+  }
+  if (!Number.isFinite(scale) || scale <= 1 || scale > 3) {
+    throw new NativeHiresFixError('Native HiRes scale must be greater than 1.0 and no more than 3.0.')
+  }
+
+  const width = snapToLatentGrid(baseWidth * scale)
+  const height = snapToLatentGrid(baseHeight * scale)
+
+  if (width > 4096 || height > 4096) {
+    throw new NativeHiresFixError(
+      `Native HiRes would produce ${width}×${height}. Lower the base resolution or upscale factor so both sides stay at or below 4096 px.`,
+    )
+  }
+
+  return { width, height }
+}
+
+/**
+ * Adds a native latent-upscale refinement pass to a simple image workflow:
+ *
+ *   KSampler → LatentUpscale → KSampler (low denoise) → VAEDecode → SaveImage
+ *
+ * The transform deliberately targets the terminal image decode rather than
+ * assuming fixed node IDs, so it works with LU's dynamic/legacy image builders
+ * and compatible imported workflows. Workflows whose final image is not fed by
+ * a core KSampler are rejected with an actionable message instead of being
+ * silently changed incorrectly.
+ */
+export function applyNativeHiresFix(
+  sourceWorkflow: Record<string, any>,
+  options: NativeHiresFixOptions,
+): NativeHiresFixResult {
+  if (!sourceWorkflow || typeof sourceWorkflow !== 'object') {
+    throw new NativeHiresFixError('Native HiRes received an invalid ComfyUI workflow.')
+  }
+  if (!Number.isFinite(options.denoise) || options.denoise <= 0 || options.denoise > 1) {
+    throw new NativeHiresFixError('Native HiRes denoise must be greater than 0 and no more than 1.')
+  }
+  if (!Number.isFinite(options.steps) || options.steps < 1 || options.steps > 200) {
+    throw new NativeHiresFixError('Native HiRes steps must be between 1 and 200.')
+  }
+  if (!UPSCALE_METHODS.has(options.upscaleMethod)) {
+    throw new NativeHiresFixError(`Unsupported Native HiRes upscale method: ${options.upscaleMethod}`)
+  }
+
+  const { width, height } = nativeHiresFinalSize(
+    options.baseWidth,
+    options.baseHeight,
+    options.scale,
+  )
+  const workflow = cloneWorkflow(sourceWorkflow)
+
+  if (Object.values(workflow).some((node: any) => node?._meta?.luNativeHiresFix === true)) {
+    throw new NativeHiresFixError('This workflow already contains LU Native HiRes nodes.')
+  }
+
+  const terminalDecodeIds = new Set<string>()
+  for (const node of Object.values(workflow)) {
+    if (!node || !IMAGE_OUTPUT_NODES.has(node.class_type)) continue
+    const imageRef = node.inputs?.images
+    if (!isNodeRef(imageRef)) continue
+    const decodeId = String(imageRef[0])
+    const decode = workflow[decodeId]
+    if (decode && IMAGE_DECODE_NODES.has(decode.class_type)) terminalDecodeIds.add(decodeId)
+  }
+
+  if (terminalDecodeIds.size !== 1) {
+    throw new NativeHiresFixError(
+      terminalDecodeIds.size === 0
+        ? 'Native HiRes could not find a final VAEDecode → SaveImage path. Use Auto or a compatible image workflow.'
+        : 'Native HiRes found multiple final image decode paths. Use Auto or a workflow with one final image output.',
+    )
+  }
+
+  const decodeId = [...terminalDecodeIds][0]
+  const decode = workflow[decodeId]
+  const samplesRef = decode?.inputs?.samples
+  if (!isNodeRef(samplesRef)) {
+    throw new NativeHiresFixError('Native HiRes could not find the sampler feeding the final image decode.')
+  }
+
+  const firstSamplerId = String(samplesRef[0])
+  const firstSampler = workflow[firstSamplerId]
+  if (!firstSampler || firstSampler.class_type !== 'KSampler') {
+    throw new NativeHiresFixError(
+      `Native HiRes currently requires a core KSampler before the final decode; this workflow uses ${firstSampler?.class_type ?? 'an unknown node'}.`,
+    )
+  }
+
+  const requiredInputs = ['model', 'positive', 'negative', 'latent_image']
+  const missing = requiredInputs.filter((key) => firstSampler.inputs?.[key] === undefined)
+  if (missing.length > 0) {
+    throw new NativeHiresFixError(`The final KSampler is missing required inputs: ${missing.join(', ')}.`)
+  }
+
+  const upscaleNodeId = nextNodeId(workflow)
+  workflow[upscaleNodeId] = {
+    class_type: 'LatentUpscale',
+    inputs: {
+      samples: [firstSamplerId, samplesRef[1]],
+      upscale_method: options.upscaleMethod,
+      width,
+      height,
+      crop: 'disabled',
+    },
+    _meta: {
+      title: 'LU Native HiRes — latent upscale',
+      luNativeHiresFix: true,
+    },
+  }
+
+  const samplerNodeId = nextNodeId(workflow)
+  workflow[samplerNodeId] = {
+    class_type: 'KSampler',
+    inputs: {
+      ...firstSampler.inputs,
+      latent_image: [upscaleNodeId, 0],
+      steps: Math.floor(options.steps),
+      denoise: options.denoise,
+    },
+    _meta: {
+      title: 'LU Native HiRes — refinement pass',
+      luNativeHiresFix: true,
+    },
+  }
+
+  decode.inputs = {
+    ...decode.inputs,
+    samples: [samplerNodeId, 0],
+  }
+
+  return {
+    workflow,
+    width,
+    height,
+    upscaleNodeId,
+    samplerNodeId,
+  }
+}

--- a/src/components/create/experimental/ParamGroups.tsx
+++ b/src/components/create/experimental/ParamGroups.tsx
@@ -3,6 +3,7 @@ import { useCreateStore } from '../../../stores/createStore'
 import { useCreateExp } from './CreateContext'
 import { cloudModelById, defaultCloudModel } from '../../../stores/cloudCatalogStore'
 import { classifyModel } from '../../../api/comfyui'
+import { nativeHiresFinalSize, type HiresUpscaleMethod } from '../../../api/hires-fix'
 import { isMlxImageHost } from '../../../api/mlx-image'
 import { INTENT_MAP } from './intents'
 import { SAMPLERS as SAMPLERS_FALLBACK, SCHEDULERS as SCHEDULERS_FALLBACK } from './badges'
@@ -49,6 +50,19 @@ export function ParamGroups() {
     (isVideo ? s.cloudVideoModel : s.cloudImageModel) || defaultCloudModel(isVideo ? 'video' : 'image')?.id || ''
   const showSteps = !(isCloud && isVideo)
   const showCfg = isCloud ? cloudModelById(cloudModelId)?.cfg === true : true
+  // Native HiRes rewrites the local ComfyUI text-to-image graph. It has no
+  // cloud, video, Edit or MLX path, so keep the control honest and scoped to
+  // the one lane that can execute it.
+  const showHiresFix = !isCloud && !isVideo && meta.id === 'image' && !isMlxLocal
+  let hiresFinal: { width: number; height: number } | null = null
+  let hiresSizeError: string | null = null
+  if (showHiresFix && s.hiresFixEnabled) {
+    try {
+      hiresFinal = nativeHiresFinalSize(s.width, s.height, s.hiresScale)
+    } catch (error) {
+      hiresSizeError = error instanceof Error ? error.message : String(error)
+    }
+  }
 
   const samplers = samplerList.length ? samplerList : SAMPLERS_FALLBACK
   const schedulers = schedulerList.length ? schedulerList : SCHEDULERS_FALLBACK
@@ -66,6 +80,60 @@ export function ParamGroups() {
           <NumberField label="Width" value={s.width} min={64} max={4096} step={64} mono onChange={(v) => s.setSize(v, s.height)} suffix="px" />
           <NumberField label="Height" value={s.height} min={64} max={4096} step={64} mono onChange={(v) => s.setSize(s.width, v)} suffix="px" />
         </div>
+        {showHiresFix && (
+          <div className={cn(
+            'overflow-hidden rounded-lg border transition-colors',
+            s.hiresFixEnabled ? 'border-white/15 bg-white/[0.05]' : 'border-white/[0.07]',
+          )}>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between px-3 py-2 text-left"
+              onClick={() => s.setHiresFixEnabled(!s.hiresFixEnabled)}
+              aria-pressed={s.hiresFixEnabled}
+            >
+              <span>
+                <span className="block t-control text-gray-300">Native HiRes</span>
+                <span className="block text-[11px] leading-4 text-gray-600">Latent upscale plus a native refinement pass</span>
+              </span>
+              <span className={cn('t-mono text-xs', s.hiresFixEnabled ? 'text-emerald-400' : 'text-gray-600')}>
+                {s.hiresFixEnabled ? 'on' : 'off'}
+              </span>
+            </button>
+
+            {s.hiresFixEnabled && (
+              <div className="space-y-3 border-t border-white/[0.07] px-3 pb-3 pt-2.5">
+                <div className="rounded-md bg-black/20 px-2.5 py-2 text-[11px] text-gray-500">
+                  {hiresFinal ? (
+                    <>
+                      <span className="t-mono text-gray-400">{s.width}×{s.height}</span>
+                      <span className="px-1.5 text-gray-700">→</span>
+                      <span className="t-mono text-gray-200">{hiresFinal.width}×{hiresFinal.height}</span>
+                    </>
+                  ) : (
+                    <span className="text-amber-400">{hiresSizeError}</span>
+                  )}
+                </div>
+                <Slider label="Upscale" min={1.1} max={3} step={0.1} value={s.hiresScale} onChange={s.setHiresScale} format={(v) => `${v.toFixed(1)}×`} />
+                <Slider label="HiRes steps" min={1} max={40} step={1} value={s.hiresSteps} onChange={s.setHiresSteps} />
+                <Slider label="HiRes denoise" min={0.05} max={1} step={0.05} value={s.hiresDenoise} onChange={s.setHiresDenoise} format={(v) => v.toFixed(2)} />
+                <Field label="Latent upscale method" help="Nearest-exact is the default and preserves hard edges. Bicubic and bilinear provide smoother interpolation; bislerp gives softer latent blending.">
+                  <Select
+                    size="sm"
+                    options={[
+                      { value: 'nearest-exact', label: 'nearest-exact' },
+                      { value: 'bislerp', label: 'bislerp' },
+                      { value: 'bicubic', label: 'bicubic' },
+                      { value: 'bilinear', label: 'bilinear' },
+                      { value: 'area', label: 'area' },
+                    ]}
+                    value={s.hiresUpscaleMethod}
+                    onChange={(value) => s.setHiresUpscaleMethod(value as HiresUpscaleMethod)}
+                  />
+                </Field>
+              </div>
+            )}
+          </div>
+        )}
       </Section>
 
       {/* OUTPUT */}

--- a/src/hooks/useCreate.ts
+++ b/src/hooks/useCreate.ts
@@ -48,6 +48,7 @@ import {
 import { useCreateStore } from '../stores/createStore'
 import { useWorkflowStore } from '../stores/workflowStore'
 import { injectParameters } from '../api/workflows'
+import { applyNativeHiresFix } from '../api/hires-fix'
 import {
   generateMlxImageDataUrl, isMlxImageHost, isMlxImageModel,
   mlxStatus, listMlxImageModels, buildMlxImageModels, mergeImageModels, mlxModelIdFor,
@@ -432,7 +433,8 @@ export function useCreate() {
     }
     const {
       mode, prompt, negativePrompt, imageModel, videoModel,
-      sampler, scheduler, steps, cfgScale, width, height, seed, batchSize, frames, fps, denoise, i2iImage, i2vImage,
+      sampler, scheduler, steps, cfgScale, width, height, seed, batchSize, frames, fps, denoise,
+      hiresFixEnabled, hiresScale, hiresDenoise, hiresSteps, hiresUpscaleMethod, i2iImage, i2vImage,
       source, mask, growMaskBy, removebg, selectedLoras, selectedVae, clipSkip,
       setIsGenerating, setProgress, setCurrentPromptId, setError, addToGallery, addToPromptHistory,
     } = state
@@ -771,6 +773,8 @@ export function useCreate() {
     } catch { /* ignore — VRAM housekeeping is best-effort */ }
 
     try {
+      let outputWidth = width
+      let outputHeight = height
       const baseParams = {
         prompt, negativePrompt, model: activeModel, sampler, scheduler, steps, cfgScale, width, height, seed, batchSize,
         ...(isRemoveBg && effInputImage ? { removebg: true, inputImage: effInputImage } : {}),
@@ -969,6 +973,25 @@ export function useCreate() {
         }
       }
 
+      // Native HiRes is a graph transform, not a special workflow. Apply
+      // it after Auto/custom workflow construction so the same switch works on
+      // every compatible local text-to-image graph. Unsupported custom graphs
+      // fail with an actionable message rather than silently ignoring the knob.
+      if (hiresFixEnabled && intent === 'image') {
+        setProgress(8, 'Adding native HiRes Fix...')
+        const hires = applyNativeHiresFix(workflow, {
+          baseWidth: width,
+          baseHeight: height,
+          scale: hiresScale,
+          denoise: hiresDenoise,
+          steps: hiresSteps,
+          upscaleMethod: hiresUpscaleMethod,
+        })
+        workflow = hires.workflow
+        outputWidth = hires.width
+        outputHeight = hires.height
+      }
+
       setProgress(10, 'Submitting to ComfyUI...')
       let promptId: string
       try {
@@ -1089,7 +1112,7 @@ export function useCreate() {
                       prompt, negativePrompt, model: activeModel,
                       modelType: mode === 'image' ? imageModelType : (videoModelsList.find(m => m.name === activeModel)?.type ?? 'wan'),
                       seed: seed === -1 ? 0 : seed,
-                      steps, cfgScale, sampler, scheduler, width, height, batchSize,
+                      steps, cfgScale, sampler, scheduler, width: outputWidth, height: outputHeight, batchSize,
                       createdAt: Date.now(), builderUsed, intent,
                     })
                   }
@@ -1187,7 +1210,7 @@ export function useCreate() {
                         prompt, negativePrompt, model: activeModel,
                         modelType: mode === 'image' ? imageModelType : (videoModelsList.find(m => m.name === activeModel)?.type ?? 'wan'),
                         seed: seed === -1 ? 0 : seed,
-                        steps, cfgScale, sampler, scheduler, width, height, batchSize,
+                        steps, cfgScale, sampler, scheduler, width: outputWidth, height: outputHeight, batchSize,
                         createdAt: Date.now(), builderUsed,
                       })
                     }
@@ -1259,7 +1282,9 @@ export function useCreate() {
             }
 
             const elapsedSec = Math.round(elapsed / 1000)
-            const expectedSteps = mode === 'video' ? steps * frames * 0.5 : steps * 2
+            const expectedSteps = mode === 'video'
+              ? steps * frames * 0.5
+              : steps + (hiresFixEnabled && intent === 'image' ? hiresSteps : 0)
             const pct = Math.min(10 + (attempts / expectedSteps * 85), 95)
 
             try {
@@ -1292,7 +1317,7 @@ export function useCreate() {
                       prompt, negativePrompt, model: activeModel,
                       modelType: mode === 'image' ? imageModelType : (videoModelsList.find(m => m.name === activeModel)?.type ?? 'wan'),
                       seed: seed === -1 ? 0 : seed,
-                      steps, cfgScale, sampler, scheduler, width, height, batchSize,
+                      steps, cfgScale, sampler, scheduler, width: outputWidth, height: outputHeight, batchSize,
                       createdAt: Date.now(), builderUsed, intent,
                     })
                   }

--- a/src/stores/createStore.ts
+++ b/src/stores/createStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { ModelType, ClassifiedModel } from '../api/comfyui'
 import { classifyModel } from '../api/comfyui'
+import type { HiresUpscaleMethod } from '../api/hires-fix'
 // ModelType includes: flux, flux2, zimage, sdxl, sd15, wan, hunyuan, unknown
 
 export type ProgressPhase = 'idle' | 'queued' | 'loading-model' | 'loading-clip' | 'loading-vae' | 'sampling' | 'decoding' | 'complete'
@@ -199,6 +200,12 @@ interface CreateState {
   frames: number
   fps: number
   denoise: number  // Denoise strength for I2I (0.0–1.0)
+  /** Native text-to-image latent upscale + refinement pass (local ComfyUI). */
+  hiresFixEnabled: boolean
+  hiresScale: number
+  hiresDenoise: number
+  hiresSteps: number
+  hiresUpscaleMethod: HiresUpscaleMethod
   i2iImage: string | null  // Uploaded image filename for I2I
   i2vImage: string | null  // Uploaded image filename for I2V models (SVD, FramePack)
 
@@ -315,6 +322,11 @@ interface CreateState {
   setFrames: (frames: number) => void
   setFps: (fps: number) => void
   setDenoise: (denoise: number) => void
+  setHiresFixEnabled: (enabled: boolean) => void
+  setHiresScale: (scale: number) => void
+  setHiresDenoise: (denoise: number) => void
+  setHiresSteps: (steps: number) => void
+  setHiresUpscaleMethod: (method: HiresUpscaleMethod) => void
   setI2iImage: (image: string | null) => void
   setI2vImage: (image: string | null) => void
 
@@ -408,6 +420,11 @@ export const useCreateStore = create<CreateState>()(
       frames: 24,
       fps: 8,
       denoise: 0.7,
+      hiresFixEnabled: false,
+      hiresScale: 1.5,
+      hiresDenoise: 1,
+      hiresSteps: 12,
+      hiresUpscaleMethod: 'nearest-exact' as HiresUpscaleMethod,
       i2iImage: null,
       i2vImage: null,
 
@@ -529,6 +546,17 @@ export const useCreateStore = create<CreateState>()(
       setFrames: (frames) => set({ frames: Math.max(1, Math.min(120, Math.floor(frames))) }),
       setFps: (fps) => set({ fps: Math.max(1, Math.min(60, Math.floor(fps))) }),
       setDenoise: (denoise) => set({ denoise: Math.max(0, Math.min(1, denoise)) }),
+      setHiresFixEnabled: (hiresFixEnabled) => set({ hiresFixEnabled }),
+      setHiresScale: (hiresScale) => set({
+        hiresScale: Math.max(1.1, Math.min(3, Math.round(hiresScale * 10) / 10)),
+      }),
+      setHiresDenoise: (hiresDenoise) => set({
+        hiresDenoise: Math.max(0.05, Math.min(1, hiresDenoise)),
+      }),
+      setHiresSteps: (hiresSteps) => set({
+        hiresSteps: Math.max(1, Math.min(200, Math.floor(hiresSteps))),
+      }),
+      setHiresUpscaleMethod: (hiresUpscaleMethod) => set({ hiresUpscaleMethod }),
       setI2iImage: (image) => set({ i2iImage: image }),
       setI2vImage: (image) => set({ i2vImage: image }),
 
@@ -677,7 +705,21 @@ export const useCreateStore = create<CreateState>()(
         const d = s.mode === 'video'
           ? (MODEL_TYPE_DEFAULTS[classifyModel(s.videoModel)] || MODEL_TYPE_DEFAULTS.unknown)
           : MODEL_TYPE_DEFAULTS[s.imageModelType]
-        set({ sampler: d.sampler, scheduler: d.scheduler, steps: d.steps, cfgScale: d.cfgScale, width: d.width, height: d.height, ...(d.frames ? { frames: d.frames } : {}), ...(d.fps ? { fps: d.fps } : {}) })
+        set({
+          sampler: d.sampler,
+          scheduler: d.scheduler,
+          steps: d.steps,
+          cfgScale: d.cfgScale,
+          width: d.width,
+          height: d.height,
+          hiresFixEnabled: false,
+          hiresScale: 1.5,
+          hiresDenoise: 1,
+          hiresSteps: 12,
+          hiresUpscaleMethod: 'nearest-exact',
+          ...(d.frames ? { frames: d.frames } : {}),
+          ...(d.fps ? { fps: d.fps } : {}),
+        })
       },
 
       setIsGenerating: (generating) => set({ isGenerating: generating, ...(generating ? {} : { progressPhase: 'idle' as ProgressPhase }) }),
@@ -720,6 +762,11 @@ export const useCreateStore = create<CreateState>()(
         frames: state.frames,
         fps: state.fps,
         denoise: state.denoise,
+        hiresFixEnabled: state.hiresFixEnabled,
+        hiresScale: state.hiresScale,
+        hiresDenoise: state.hiresDenoise,
+        hiresSteps: state.hiresSteps,
+        hiresUpscaleMethod: state.hiresUpscaleMethod,
         // Media bytes never go to localStorage — a handful of multi-MB base64
         // dataUrls would blow the origin quota (~5-10 MB in WebView2/WKWebView)
         // and every subsequent set() would throw, killing ALL create-store


### PR DESCRIPTION
Added Native HiRes directly to local image generation.
Performs a second latent upscale and refinement pass without requiring a custom workflow.
Supports configurable scale, steps, denoise, and upscale method.
Defaults to nearest-exact with 1.0 denoise.
Shows the calculated final resolution in the UI.
Includes compatibility checks and automated tests.
Confirmed to merge cleanly with the current origin/master.