### PR TITLE
Fix Apple Silicon local media setup and memory handoff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,9 @@ Thanks for your interest in contributing! This project thrives on community inpu
 ### Prerequisites
 
 - **Node.js** 18+ ([download](https://nodejs.org/))
+- **Rust stable** ([install](https://rustup.rs/)) — required by the Tauri desktop app
 - **Ollama** ([download](https://ollama.com/)) — for text model testing
-- **ComfyUI** (optional) — only needed for image/video gen features
+- **ComfyUI** (optional) — needed for image/video testing outside the Apple Silicon local lanes
 - **Git** (obviously)
 
 ### Dev Setup
@@ -18,6 +19,25 @@ git clone https://github.com/PurpleDoubleD/locally-uncensored.git
 cd locally-uncensored
 npm install
 ```
+
+#### Apple Silicon desktop builds
+
+The bundled `llama-server` binary is intentionally not committed. Build the
+native arm64 sidecar before the first Tauri run; the script enables Metal and
+embeds its shaders so the resulting app does not need a separate llama.cpp
+install:
+
+```bash
+xcode-select --install              # once, if Command Line Tools are missing
+brew install cmake python@3.12
+bash scripts/build-llama.sh
+bash scripts/build-llama.sh --check
+npm run tauri:dev
+```
+
+Ollama remains the recommended text backend on macOS. Local image and video
+dependencies are installed into LU's own Python environment from the Create
+tab; ComfyUI is not required for those Apple Silicon lanes.
 
 You have three dev workflows, depending on what you're working on:
 

--- a/src-tauri/src/commands/engine.rs
+++ b/src-tauri/src/commands/engine.rs
@@ -660,7 +660,7 @@ fn start_bundled_engine_blocking(
     // just-active 14B loaded, this engine's own load crawled through paging and
     // blew the health budget (live repro 2026-07-31; an IDLE model gets evicted
     // fine). Evict via keep_alive:0 — Ollama reloads lazily on its next use.
-    if crate::commands::process::offload_ollama_loaded_models() {
+    if !crate::commands::process::offload_ollama_loaded_models().is_empty() {
         println!("[Engine] asked Ollama to evict loaded models before engine start");
     }
 

--- a/src-tauri/src/commands/mlx.rs
+++ b/src-tauri/src/commands/mlx.rs
@@ -31,6 +31,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 pub const MLX_PORT: u16 = 47712;
+const IMAGE_ENGINE_READY_MARKER: &str = ".image-engine-ready";
 
 fn mlx_root() -> PathBuf {
     crate::os_paths::data_dir().join("mlx")
@@ -40,8 +41,8 @@ fn venv_python() -> PathBuf {
     mlx_root().join("venv/bin/python")
 }
 
-fn venv_pip() -> PathBuf {
-    mlx_root().join("venv/bin/pip")
+fn image_engine_is_installed(root: &std::path::Path) -> bool {
+    root.join("venv/bin/python").is_file() && root.join(IMAGE_ENGINE_READY_MARKER).is_file()
 }
 
 /// The HuggingFace token the user stored in Settings, held in memory for the
@@ -96,7 +97,13 @@ fn sidecar_running() -> bool {
 }
 
 pub async fn mlx_status(_state: &AppState, _args: &Value) -> CmdResult {
-    let installed = venv_python().exists();
+    // A venv is created before pip runs. Its Python existing therefore proves
+    // only that setup started, not that torch/diffusers ever installed. A pip
+    // failure used to strand the Mac permanently: the next click saw the bare
+    // venv as "installed", skipped repair, and downloaded a model the engine
+    // could not load. The marker is written only after the dependency install
+    // succeeds.
+    let installed = image_engine_is_installed(&mlx_root());
     let running = sidecar_running();
     // When the sidecar is up, surface what it's holding so the UI can show a
     // "free memory" control while a model is resident.
@@ -225,8 +232,8 @@ fn install_mlx_steps(slot: &crate::install_state::InstallSlot) -> Result<(), Str
     std::fs::write(&server_path, SERVER_PY).map_err(|e| format!("write server.py: {}", os_error::english(&e)))?;
 
     slot.log("running pip install (this pulls torch + diffusers, ~3 GB)");
-    let out = Command::new(venv_pip())
-        .args(["install", "--upgrade", "-r", req_path.to_str().unwrap()])
+    let out = crate::python::isolated_pip_install_command(venv_python())
+        .args(["-r", req_path.to_str().unwrap()])
         .output()
         .map_err(|e| format!("pip install spawn: {}", os_error::english(&e)))?;
     if !out.status.success() {
@@ -236,6 +243,10 @@ fn install_mlx_steps(slot: &crate::install_state::InstallSlot) -> Result<(), Str
         ));
     }
     slot.log("pip install complete");
+
+    std::fs::write(mlx_root().join(IMAGE_ENGINE_READY_MARKER), b"ready\n")
+        .map_err(|e| format!("write image engine ready marker: {}", os_error::english(&e)))?;
+    slot.log("image engine dependencies ready");
 
     // Same pattern set as the catalog entry, so the fp32 duplicates (10+ GB)
     // stay on HuggingFace and image_model_is_installed() flips true.
@@ -1007,6 +1018,18 @@ mod tests {
         let p = venv_python();
         let s = p.to_string_lossy();
         assert!(s.ends_with("venv/bin/python"));
+    }
+
+    #[test]
+    fn a_bare_venv_is_not_a_finished_image_engine() {
+        let root = std::env::temp_dir().join(format!("lu-mlx-ready-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("venv/bin")).unwrap();
+        std::fs::write(root.join("venv/bin/python"), b"stub").unwrap();
+        assert!(!image_engine_is_installed(&root));
+        std::fs::write(root.join(IMAGE_ENGINE_READY_MARKER), b"ready\n").unwrap();
+        assert!(image_engine_is_installed(&root));
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -2436,7 +2436,8 @@ fn offload_local_models_blocking(state: &AppState, include_comfyui: Option<bool>
     }
 
     // 3) Ollama — keep `serve` up (cheap, idle) but evict every loaded model.
-    if offload_ollama_loaded_models() {
+    let ollama_models = offload_ollama_loaded_models();
+    if !ollama_models.is_empty() {
         freed.push("ollama");
     }
 
@@ -2448,18 +2449,18 @@ fn offload_local_models_blocking(state: &AppState, include_comfyui: Option<bool>
     }
 
     println!("[Offload] released local model backends (comfyui={}): {:?}", free_comfy, freed);
-    Ok(serde_json::json!({ "offloaded": freed }))
+    Ok(serde_json::json!({ "offloaded": freed, "ollama_models": ollama_models }))
 }
 
 /// Evict every model Ollama currently holds in memory via `keep_alive: 0`,
 /// leaving `ollama serve` running (idle serve is cheap). Best-effort.
-pub(crate) fn offload_ollama_loaded_models() -> bool {
+pub(crate) fn offload_ollama_loaded_models() -> Vec<String> {
     let client = match reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
         .build()
     {
         Ok(c) => c,
-        Err(_) => return false,
+        Err(_) => return Vec::new(),
     };
     let ps = match client
         .get("http://localhost:11434/api/ps")
@@ -2468,13 +2469,13 @@ pub(crate) fn offload_ollama_loaded_models() -> bool {
         .and_then(|r| r.json::<serde_json::Value>().ok())
     {
         Some(v) => v,
-        None => return false,
+        None => return Vec::new(),
     };
     let models = match ps.get("models").and_then(|m| m.as_array()) {
         Some(a) => a,
-        None => return false,
+        None => return Vec::new(),
     };
-    let mut any = false;
+    let mut unloaded = Vec::new();
     for m in models {
         if let Some(name) = m
             .get("name")
@@ -2485,10 +2486,10 @@ pub(crate) fn offload_ollama_loaded_models() -> bool {
                 .post("http://localhost:11434/api/generate")
                 .json(&serde_json::json!({ "model": name, "keep_alive": 0 }))
                 .send();
-            any = true;
+            unloaded.push(name.to_string());
         }
     }
-    any
+    unloaded
 }
 
 /// Ask ComfyUI to unload checkpoints and free memory, keeping the server up so

--- a/src-tauri/src/commands/video.rs
+++ b/src-tauri/src/commands/video.rs
@@ -269,8 +269,8 @@ pub(crate) fn ensure_python_module(
         return Ok(());
     }
     slot.log(format!("installing {pip_spec} (one-time)"));
-    let mut cmd = Command::new(python);
-    cmd.args(["-m", "pip", "install", "--upgrade", pip_spec]);
+    let mut cmd = crate::python::isolated_pip_install_command(python);
+    cmd.arg(pip_spec);
     run_streamed(slot, &mut cmd)
         .map_err(|e| format!("pip install {pip_spec}: {e}"))?;
     if !python_has_module(python, module) {
@@ -398,14 +398,8 @@ pub fn video_install_mlx(state: &AppState, _args: &Value) -> CmdResult {
     slot.start();
     let slot2 = slot.clone();
     std::thread::spawn(move || {
-        let mut cmd = Command::new(&python);
-        cmd.args([
-            "-m",
-            "pip",
-            "install",
-            "--upgrade",
-            "git+https://github.com/Blaizzy/mlx-video.git",
-        ]);
+        let mut cmd = crate::python::isolated_pip_install_command(&python);
+        cmd.arg("git+https://github.com/Blaizzy/mlx-video.git");
         if let Err(e) = run_streamed(&slot2, &mut cmd) {
             slot2.fail(e);
         } else if !mlx_video_installed(&python) {
@@ -558,6 +552,12 @@ struct GenerateArgs {
     id: String,
     prompt: String,
     #[serde(default)]
+    steps: Option<u32>,
+    #[serde(default)]
+    width: Option<u32>,
+    #[serde(default)]
+    height: Option<u32>,
+    #[serde(default)]
     seconds: Option<f32>,
     #[serde(default)]
     fps: Option<u32>,
@@ -612,6 +612,17 @@ pub fn video_generate(state: &AppState, args: &Value) -> CmdResult {
 
     let mdir = weights_dir(entry);
 
+    let width = a.width.unwrap_or(entry.default_width);
+    let height = a.height.unwrap_or(entry.default_height);
+    for (label, value) in [("width", width), ("height", height)] {
+        if !valid_video_dimension(value) {
+            return Err(bad_request(format!(
+                "{label} must be between 64 and 2048 and divisible by 16 (got {value})"
+            )));
+        }
+    }
+    let steps = a.steps.map(|n| n.clamp(1, 100));
+
     // Frame count: caller can override via `seconds * fps`; otherwise use
     // the catalog default. mlx-video's frame flags count frames, not seconds.
     let fps = a.fps.unwrap_or(24).max(1);
@@ -634,9 +645,9 @@ pub fn video_generate(state: &AppState, args: &Value) -> CmdResult {
         cmd.arg("--model-dir")
             .arg(mdir.as_os_str())
             .arg("--width")
-            .arg(entry.default_width.to_string())
+            .arg(width.to_string())
             .arg("--height")
-            .arg(entry.default_height.to_string())
+            .arg(height.to_string())
             .arg("--num-frames")
             .arg(frames.to_string())
             .arg("--output-path")
@@ -650,6 +661,9 @@ pub fn video_generate(state: &AppState, args: &Value) -> CmdResult {
             .arg(out_path.as_os_str())
             .arg("-n")
             .arg(frames.to_string());
+    }
+    if let Some(steps) = steps {
+        cmd.arg("--steps").arg(steps.to_string());
     }
     if let Some(seed) = a.seed {
         cmd.arg("--seed").arg(seed.to_string());
@@ -778,6 +792,10 @@ fn clamp_frames(family: &str, frames: u32) -> u32 {
     f - ((f - 1) % 4)
 }
 
+fn valid_video_dimension(value: u32) -> bool {
+    (64..=2048).contains(&value) && value % 16 == 0
+}
+
 pub(crate) fn run_streamed(slot: &crate::install_state::InstallSlot, cmd: &mut Command) -> Result<(), String> {
     use std::io::{BufRead, BufReader};
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
@@ -856,6 +874,16 @@ mod tests {
         assert_eq!(clamp_frames("wan_2", 1), 5);
         assert_eq!(clamp_frames("ltx_2", 80), 80);
         assert_eq!(clamp_frames("ltx_2", 0), 1);
+    }
+
+    #[test]
+    fn video_dimensions_match_mlx_grid_and_safety_bounds() {
+        assert!(valid_video_dimension(320));
+        assert!(valid_video_dimension(832));
+        assert!(valid_video_dimension(2048));
+        assert!(!valid_video_dimension(63));
+        assert!(!valid_video_dimension(321));
+        assert!(!valid_video_dimension(2064));
     }
 
     #[test]

--- a/src-tauri/src/python.rs
+++ b/src-tauri/src/python.rs
@@ -7,6 +7,26 @@ use std::os::windows::process::CommandExt;
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+/// Build a pip install command that cannot inherit the user's pip policy.
+///
+/// LU installs Python packages only into environments it owns. A perfectly
+/// valid user config such as `global.user = true` makes ordinary pip commands
+/// add `--user`; pip then refuses to run inside a venv with:
+///
+/// ```text
+/// Can not perform a '--user' install. User site-packages are not visible in
+/// this virtualenv.
+/// ```
+///
+/// `--isolated` tells pip to ignore user configuration and all `PIP_*`
+/// environment variables. Keep it before the `install` subcommand: that is
+/// where pip's global options are parsed.
+pub fn isolated_pip_install_command(python: impl AsRef<std::ffi::OsStr>) -> Command {
+    let mut cmd = Command::new(python);
+    cmd.args(["-m", "pip", "--isolated", "install", "--upgrade"]);
+    cmd
+}
+
 /// True when a `PYTHONHOME` / `PYTHONPATH` value points inside an AppImage's
 /// throwaway mount instead of a real Python installation.
 ///
@@ -301,6 +321,16 @@ pub fn is_real_python(bin: &str) -> bool {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn app_owned_pip_ignores_user_configuration() {
+        let cmd = isolated_pip_install_command("python3");
+        let args = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(args, ["-m", "pip", "--isolated", "install", "--upgrade"]);
+    }
 
     // ── AppImage Python env poisoning (numbrain, Discord 2026-07-28) ────────
 

--- a/src/api/__tests__/create-render-handoff.test.ts
+++ b/src/api/__tests__/create-render-handoff.test.ts
@@ -65,7 +65,7 @@ import { useSettingsStore } from '../../stores/settingsStore'
 const GB = 1024 * 1024 * 1024
 
 /** backendCall programmed like the live box: engine up, save works. */
-function mockBackends(opts?: { engineRunning?: boolean; saveOk?: boolean }) {
+function mockBackends(opts?: { engineRunning?: boolean; saveOk?: boolean; offloadedOllama?: string[] }) {
   backendCall.mockImplementation(async (cmd: unknown, args?: unknown) => {
     if (cmd === 'bundled_engine_status') {
       return (opts?.engineRunning ?? true)
@@ -78,6 +78,7 @@ function mockBackends(opts?: { engineRunning?: boolean; saveOk?: boolean }) {
       return { ok: true }
     }
     if (cmd === 'lmstudio_list_loaded') return { loaded: [] }
+    if (cmd === 'offload_local_models') return { ollama_models: opts?.offloadedOllama ?? [] }
     return {}
   })
 }
@@ -106,7 +107,7 @@ beforeEach(() => {
     json: async () => ({ models: [{ name: 'qwen:14b', size_vram: 9 * GB }] }),
   })
   mockBackends()
-  useSettingsStore.getState().updateSettings({ exclusiveVramMode: 'auto' })
+  useSettingsStore.getState().updateSettings({ exclusiveVramMode: 'auto', contextWindowOverride: 0 })
 })
 
 afterEach(() => {
@@ -146,6 +147,13 @@ describe('evictChatBackendsForRender', () => {
     expect(haul.bundled?.slotSaved).toBe(false)
     expect(callsTo('offload_local_models')).toHaveLength(1)
   })
+
+  it('remembers the Ollama model returned by the authoritative Rust offloader', async () => {
+    localFetch.mockResolvedValue({ ok: true, json: async () => ({ models: [] }) })
+    mockBackends({ offloadedOllama: ['qwen-from-offloader:30b'] })
+    const haul = await evictChatBackendsForRender()
+    expect(haul.ollamaModel).toBe('qwen-from-offloader:30b')
+  })
 })
 
 describe('restoreChatBackendsAfterRender', () => {
@@ -168,6 +176,12 @@ describe('restoreChatBackendsAfterRender', () => {
     const lmsLoads = callsTo('lmstudio_load_model')
     expect(lmsLoads).toHaveLength(1)
     expect(lmsLoads[0][1]).toMatchObject({ model: 'lms-model', contextLength: 16384 })
+  })
+
+  it('restores Ollama with the context window selected in LU', async () => {
+    useSettingsStore.getState().updateSettings({ contextWindowOverride: 16_384 })
+    await restoreChatBackendsAfterRender(fullHaul(), 0)
+    expect(loadModel).toHaveBeenCalledWith('qwen:14b', 16_384)
   })
 
   it('NEGATIVE: an unsaved slot is not restored (engine still restarts)', async () => {
@@ -225,6 +239,10 @@ describe('wiring: useCreate uses the hand-off helpers', () => {
     const src = read('../../hooks/useCreate.ts')
     expect(src).toContain('evictChatBackendsForRender()')
     expect(src).toContain('restoreChatBackendsAfterRender(renderEviction)')
+    // One pair protects the Apple-Silicon MLX-video lane and one protects the
+    // ComfyUI lane. Both compete with Ollama for local GPU/unified memory.
+    expect(src.match(/evictChatBackendsForRender\(\)/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(src.match(/restoreChatBackendsAfterRender\(renderEviction\)/g)?.length).toBeGreaterThanOrEqual(3)
     // The exact uncaptured kill Z36 flagged must not come back.
     expect(src).not.toContain("backendCall('offload_local_models'")
     expect(src).not.toContain("backendCall('lmstudio_unload_model'")

--- a/src/api/__tests__/mlx-install.test.ts
+++ b/src/api/__tests__/mlx-install.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { starterForEmptyImageLane } from '../mlx-install'
+
+describe('starterForEmptyImageLane', () => {
+  it('does not download a second model after engine setup pre-pulled one', () => {
+    expect(starterForEmptyImageLane([
+      { sizeGB: 2.6, installed: true, id: 'starter' },
+      { sizeGB: 4.4, installed: false, id: 'next' },
+    ])).toBeNull()
+  })
+
+  it('picks the smallest model when the lane really is empty', () => {
+    expect(starterForEmptyImageLane([
+      { sizeGB: 7, installed: false, id: 'large' },
+      { sizeGB: 2.6, installed: false, id: 'starter' },
+    ])?.id).toBe('starter')
+  })
+})

--- a/src/api/__tests__/mlx-video.test.ts
+++ b/src/api/__tests__/mlx-video.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ backendCall: vi.fn() }))
+
+vi.mock('../backend', () => ({
+  backendCall: (...args: unknown[]) => mocks.backendCall(...args),
+}))
+
+import { generateVideo } from '../mlx-video'
+
+describe('generateVideo', () => {
+  beforeEach(() => {
+    mocks.backendCall.mockReset()
+    mocks.backendCall.mockResolvedValue({ ok: true, jobId: 'job', pid: 1, output: '/tmp/out.mp4' })
+  })
+
+  it('forwards the Apple video quality and size selected in Create', async () => {
+    await generateVideo({
+      id: 'wan21-t2v-1.3b',
+      prompt: 'ocean waves',
+      steps: 4,
+      width: 544,
+      height: 320,
+      seconds: 0.6,
+      fps: 16,
+      seed: 7,
+    })
+
+    expect(mocks.backendCall).toHaveBeenCalledWith('video_generate', {
+      args: {
+        id: 'wan21-t2v-1.3b',
+        prompt: 'ocean waves',
+        steps: 4,
+        width: 544,
+        height: 320,
+        seconds: 0.6,
+        fps: 16,
+        init_image: undefined,
+        seed: 7,
+      },
+    })
+  })
+})

--- a/src/api/__tests__/ollama-load.test.ts
+++ b/src/api/__tests__/ollama-load.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ localFetch: vi.fn() }))
+
+vi.mock('../backend', () => ({
+  isTauri: () => true,
+  ollamaUrl: (path: string) => `http://localhost:11434/api${path}`,
+  localFetch: (...args: unknown[]) => mocks.localFetch(...args),
+  localFetchStream: vi.fn(),
+}))
+
+import { loadModel } from '../ollama'
+
+describe('loadModel', () => {
+  beforeEach(() => {
+    mocks.localFetch.mockReset()
+    mocks.localFetch.mockResolvedValue(new Response('{}', { status: 200 }))
+  })
+
+  it('warms Ollama with LU\'s selected context window when provided', async () => {
+    await loadModel('qwen:30b', 16_384)
+    const options = mocks.localFetch.mock.calls[0][1] as { body: string }
+    expect(JSON.parse(options.body)).toMatchObject({
+      model: 'qwen:30b',
+      keep_alive: '10m',
+      options: { num_ctx: 16_384 },
+    })
+  })
+})

--- a/src/api/mcp/builtin-tools.ts
+++ b/src/api/mcp/builtin-tools.ts
@@ -1177,6 +1177,9 @@ async function executeVideoGenerateMlx(prompt: string, merged: Record<string, an
     job = await generateMlxVideo({
       id: model.id,
       prompt,
+      steps: typeof merged.steps === 'number' ? merged.steps : undefined,
+      width: typeof merged.width === 'number' ? merged.width : undefined,
+      height: typeof merged.height === 'number' ? merged.height : undefined,
       seconds,
       fps,
       seed: typeof merged.seed === 'number' ? merged.seed : undefined,

--- a/src/api/mlx-install.ts
+++ b/src/api/mlx-install.ts
@@ -80,6 +80,15 @@ function smallest<T extends { sizeGB: number; installed: boolean }>(models: T[])
   return missing.reduce((a, b) => (b.sizeGB < a.sizeGB ? b : a))
 }
 
+/** The image-engine install already pre-pulls the smallest model. If any image
+ * model is now installed, the local lane is usable and setup is finished; do
+ * not interpret the next missing catalog entry as another required download. */
+export function starterForEmptyImageLane<T extends { sizeGB: number; installed: boolean }>(
+  models: T[],
+): T | null {
+  return models.some((m) => m.installed) ? null : smallest(models)
+}
+
 /**
  * Bring local MLX media for `kind` from nothing to usable.
  *
@@ -100,9 +109,9 @@ export async function installMlxStack(
       useMlxInstallStore.getState().watch('image-engine', 'MLX image engine')
       await awaitSlot(getMlxImageEngineStatus, 'Image engine install', onProgress, signal)
     }
-    const pick = smallest(await listMlxImageModels())
-    // Null means every catalog entry is already installed — the caller's empty
-    // model list was a stale read, not a missing install. Nothing left to do.
+    const pick = starterForEmptyImageLane(await listMlxImageModels())
+    // The engine installer pre-pulls the starter. Null therefore means the
+    // local image lane is already usable; do not fetch a second model.
     if (!pick) return
     onProgress?.(`Downloading ${pick.name} (${pick.sizeGB} GB)…`)
     await installMlxImageModel(pick.id)

--- a/src/api/mlx-video.ts
+++ b/src/api/mlx-video.ts
@@ -68,6 +68,9 @@ export interface InstallStatus {
 export interface GenerateParams {
   id: string
   prompt: string
+  steps?: number
+  width?: number
+  height?: number
   seconds?: number
   fps?: number
   initImage?: string
@@ -115,6 +118,9 @@ export async function generateVideo(params: GenerateParams): Promise<GenerateRes
   const body = {
     id: params.id,
     prompt: params.prompt,
+    steps: params.steps,
+    width: params.width,
+    height: params.height,
     seconds: params.seconds,
     fps: params.fps,
     init_image: params.initImage,

--- a/src/api/ollama.ts
+++ b/src/api/ollama.ts
@@ -363,10 +363,11 @@ export async function scanInstalledModels(): Promise<ModelCapabilityCheck[]> {
   return Promise.all(probeable.map(m => checkModelCapability(m.name)))
 }
 
-export async function loadModel(name: string): Promise<void> {
+export async function loadModel(name: string, numCtx?: number): Promise<void> {
+  const options = typeof numCtx === 'number' && numCtx > 0 ? { num_ctx: numCtx } : undefined
   const res = await localFetch(ollamaUrl("/generate"), {
     method: "POST",
-    body: JSON.stringify({ model: name, prompt: "", stream: false, keep_alive: "10m" }),
+    body: JSON.stringify({ model: name, prompt: "", stream: false, keep_alive: "10m", ...(options ? { options } : {}) }),
   })
   if (!res.ok) {
     const { parseOllamaError, ModelLoadError } = await import("../lib/ollama-errors")

--- a/src/api/vram-handoff.ts
+++ b/src/api/vram-handoff.ts
@@ -1839,10 +1839,17 @@ async function evictBody(): Promise<RenderEviction> {
   // made: offload_local_models stops Ollama residents and both managed
   // sidecars, lmstudio_unload_model clears LM Studio. Best effort, a failed
   // call must never block a render.
-  await Promise.all([
-    backendCall('offload_local_models', { includeComfyui: false }).catch(() => {}),
+  const [offloadResult] = await Promise.all([
+    backendCall<{ ollama_models?: string[] }>('offload_local_models', { includeComfyui: false }).catch(() => null),
     backendCall('lmstudio_unload_model', { model: '--all' }).catch(() => {}),
   ])
+  // The Rust offloader reads /api/ps immediately before eviction and returns
+  // the exact names it removed. Treat that as the authoritative fallback when
+  // the frontend's earlier /api/ps probe raced or failed — otherwise the model
+  // is gone but the restore haul forgets what to reload.
+  if (!result.ollamaModel && offloadResult?.ollama_models?.length) {
+    result.ollamaModel = offloadResult.ollama_models[0]
+  }
 
   // Merge an inherited haul: it describes models that are STILL evicted from
   // an earlier render whose restore never ran. Fresh captures win on
@@ -1903,7 +1910,9 @@ async function restoreBody(evicted: RenderEviction, graceMs: number, myEpoch: nu
   }
   if (todo.ollamaModel) {
     try {
-      await loadModel(todo.ollamaModel)
+      const numCtx = useSettingsStore.getState().settings.contextWindowOverride
+      if (numCtx > 0) await loadModel(todo.ollamaModel, numCtx)
+      else await loadModel(todo.ollamaModel)
     } catch (e) {
       // No ComfyUI-restart recovery here on purpose: on the Create tab the
       // user's next step is usually another render, so stopping ComfyUI to

--- a/src/hooks/useCreate.ts
+++ b/src/hooks/useCreate.ts
@@ -576,15 +576,27 @@ export function useCreate() {
 
       setIsGenerating(true)
       state.setProgressPhase('loading-model')
-      setProgress(0, 'Starting MLX video generation...')
+      setProgress(0, 'Freeing unified memory for MLX video...')
       addToPromptHistory(prompt)
       const startTime = Date.now()
       abortRef.current = new AbortController()
+      // Apple Silicon has one unified memory pool: a resident Ollama model and
+      // MLX video weights compete for the same RAM. Use the same reversible
+      // hand-off as ComfyUI renders so a large local chat model cannot push
+      // mlx-video into swap. The selected Ollama model is restored afterward.
+      let renderEviction: RenderEviction | null = null
+      try {
+        renderEviction = await evictChatBackendsForRender()
+      } catch { /* unified-memory housekeeping is best-effort */ }
+      setProgress(0, 'Starting MLX video generation...')
       let result: Awaited<ReturnType<typeof generateVideo>>
       try {
         result = await generateVideo({
           id: catalogId,
           prompt,
+          steps,
+          width,
+          height,
           seconds: Math.max(0.5, frames / Math.max(1, fps)),
           fps,
           seed: runSeed,
@@ -593,6 +605,7 @@ export function useCreate() {
         useCreateStore.getState().setError(`Failed to start: ${e instanceof Error ? e.message : String(e)}`)
         useCreateStore.getState().setIsGenerating(false)
         abortRef.current = null
+        if (renderEviction) void restoreChatBackendsAfterRender(renderEviction)
         return
       }
       try {
@@ -666,6 +679,7 @@ export function useCreate() {
         useCreateStore.getState().setIsGenerating(false)
         useCreateStore.getState().setProgress(0)
         abortRef.current = null
+        if (renderEviction) void restoreChatBackendsAfterRender(renderEviction)
       }
       return
     }


### PR DESCRIPTION
## Summary

- make app-owned Python installs ignore user pip policy, and detect/recover incomplete Apple image-engine installs
- avoid a redundant second image-model download after engine setup pre-pulls the starter
- forward Create's selected MLX video steps and dimensions through Tauri
- evict resident Ollama models before MLX video generation and restore the selected model/context afterward
- document the native arm64/Metal sidecar and Apple Silicon development path

## Live Apple Silicon validation

Tested on an Apple M5 Pro (20-core GPU, 48 GB unified memory), macOS 26.5.1, arm64:

- Ollama 0.32.15 with a 30B Q4 abliterated model at a 16,384-token context
- native arm64 Metal llama sidecar boots and answers its health endpoint
- real 512×512 image generated through PyTorch MPS/Metal
- real Wan 2.1 1.3B MLX video generated at 560×320, 16 fps (33 requested frames; 36 encoded distinct frames, 2.25 s)
- Ollama resident allocation dropped from 20.36 GB to zero during the MLX render, then restored automatically at the same 16,384-token context
- release .app produced; main binary and sidecar are arm64 and pass deep strict codesign verification

## Tests

- `cargo test` — 428 passed, 3 ignored
- `npx vitest run` — 5,411 passed, 3 skipped
- `npx tsc --noEmit`
- `git diff --check`
- `bash scripts/build-llama.sh --check`